### PR TITLE
Remove the unsupported 'insecure_registry' for >=docker 3.0.0

### DIFF
--- a/kolla/tests/test_build.py
+++ b/kolla/tests/test_build.py
@@ -57,6 +57,17 @@ class TasksTest(base.TestCase):
         self.imageChild.parent = self.image
         self.imageChild.path = self.useFixture(fixtures.TempDir()).path
 
+    @mock.patch('docker.version', '2.7.0')
+    @mock.patch.dict(os.environ, clear=True)
+    @mock.patch('docker.APIClient')
+    def test_push_image_before_v3_0_0(self, mock_client):
+        self.dc = mock_client
+        pusher = build.PushTask(self.conf, self.image)
+        pusher.run()
+        mock_client().push.assert_called_once_with(
+            self.image.canonical_name, stream=True, insecure_registry=True)
+
+    @mock.patch('docker.version', '3.0.0')
     @mock.patch.dict(os.environ, clear=True)
     @mock.patch('docker.APIClient')
     def test_push_image(self, mock_client):
@@ -64,7 +75,7 @@ class TasksTest(base.TestCase):
         pusher = build.PushTask(self.conf, self.image)
         pusher.run()
         mock_client().push.assert_called_once_with(
-            self.image.canonical_name, stream=True, insecure_registry=True)
+            self.image.canonical_name, stream=True)
 
     @mock.patch.dict(os.environ, clear=True)
     @mock.patch('docker.APIClient')


### PR DESCRIPTION
The argument of 'insecure_registry' for image push has been removed
by this commit (in docker 3.0.0):
https://github.com/docker/docker-py/commit/b180b8770a265e33099bd6da76c3e556a1028491

Actually this argument was marked as deprecated and unfunctional
before this removing.

This commit is to remove this parameter at invoking the push() function
when docker version >= 3.0.0.

Change-Id: Ifa7d304d08a4073dcb1dff751d5a443c112cd377
Closes-Bug: #1746703