### PR TITLE
copy iPXE NBP to /tftpboot during iPXE bootstrap

### DIFF
--- a/docker/ironic/ironic-pxe/extend_start.sh
+++ b/docker/ironic/ironic-pxe/extend_start.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 
-function bootstrap_pxe() {
+function prepare_pxe() {
     chown -R ironic: /tftpboot
     for pxe_file in /var/lib/tftpboot/pxelinux.0 /var/lib/tftpboot/chain.c32 /usr/lib/syslinux/pxelinux.0 \
                     /usr/lib/syslinux/chain.c32 /usr/lib/PXELINUX/pxelinux.0 \
@@ -10,26 +10,22 @@ function bootstrap_pxe() {
             cp "$pxe_file" /tftpboot
         fi
     done
-    exit 0
 }
 
-function bootstrap_ipxe() {
+function prepare_ipxe() {
     if [[ "${KOLLA_BASE_DISTRO}" =~ debian|ubuntu ]]; then
         cp /usr/lib/ipxe/{undionly.kpxe,ipxe.efi} /tftpboot
     elif [[ "${KOLLA_BASE_DISTRO}" =~ centos|oraclelinux|rhel ]]; then
         cp /usr/share/ipxe/{undionly.kpxe,ipxe.efi} /tftpboot
     fi
-    exit 0
 }
 
 # Bootstrap and exit if KOLLA_BOOTSTRAP variable is set. This catches all cases
 # of the KOLLA_BOOTSTRAP variable being set, including empty.
 if [[ "${!KOLLA_BOOTSTRAP[@]}" ]]; then
-    if [[ "${!KOLLA_BOOTSTRAP_IPXE[@]}" ]]; then
-        bootstrap_ipxe
-    else
-        bootstrap_pxe
-    fi
+    prepare_pxe
+    prepare_ipxe
+    exit 0
 fi
 
 # NOTE(pbourke): httpd will not clean up after itself in some cases which

--- a/docker/ironic/ironic-pxe/extend_start.sh
+++ b/docker/ironic/ironic-pxe/extend_start.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 
-# Bootstrap and exit if KOLLA_BOOTSTRAP variable is set. This catches all cases
-# of the KOLLA_BOOTSTRAP variable being set, including empty.
-if [[ "${!KOLLA_BOOTSTRAP[@]}" ]]; then
+
+function bootstrap_pxe() {
     chown -R ironic: /tftpboot
     for pxe_file in /var/lib/tftpboot/pxelinux.0 /var/lib/tftpboot/chain.c32 /usr/lib/syslinux/pxelinux.0 \
                     /usr/lib/syslinux/chain.c32 /usr/lib/PXELINUX/pxelinux.0 \
@@ -12,6 +11,25 @@ if [[ "${!KOLLA_BOOTSTRAP[@]}" ]]; then
         fi
     done
     exit 0
+}
+
+function bootstrap_ipxe() {
+    if [[ "${KOLLA_BASE_DISTRO}" =~ debian|ubuntu ]]; then
+        cp /usr/lib/ipxe/{undionly.kpxe,ipxe.efi} /tftpboot
+    elif [[ "${KOLLA_BASE_DISTRO}" =~ centos|oraclelinux|rhel ]]; then
+        cp /usr/share/ipxe/{undionly.kpxe,ipxe.efi} /tftpboot
+    fi
+    exit 0
+}
+
+# Bootstrap and exit if KOLLA_BOOTSTRAP variable is set. This catches all cases
+# of the KOLLA_BOOTSTRAP variable being set, including empty.
+if [[ "${!KOLLA_BOOTSTRAP[@]}" ]]; then
+    if [[ "${!KOLLA_BOOTSTRAP_IPXE[@]}" ]]; then
+        bootstrap_ipxe
+    else
+        bootstrap_pxe
+    fi
 fi
 
 # NOTE(pbourke): httpd will not clean up after itself in some cases which

--- a/docker/ironic/ironic-pxe/extend_start.sh
+++ b/docker/ironic/ironic-pxe/extend_start.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 
-function prepare_pxe() {
+function prepare_pxe {
     chown -R ironic: /tftpboot
     for pxe_file in /var/lib/tftpboot/pxelinux.0 /var/lib/tftpboot/chain.c32 /usr/lib/syslinux/pxelinux.0 \
                     /usr/lib/syslinux/chain.c32 /usr/lib/PXELINUX/pxelinux.0 \
@@ -12,7 +12,7 @@ function prepare_pxe() {
     done
 }
 
-function prepare_ipxe() {
+function prepare_ipxe {
     if [[ "${KOLLA_BASE_DISTRO}" =~ debian|ubuntu ]]; then
         cp /usr/lib/ipxe/{undionly.kpxe,ipxe.efi} /tftpboot
     elif [[ "${KOLLA_BASE_DISTRO}" =~ centos|oraclelinux|rhel ]]; then


### PR DESCRIPTION
This enables chainloading of iPXE from a standard PXE environment