### PR TITLE
Add support for building Logstash in RHEL/Centos

### DIFF
--- a/docker/base/Dockerfile.j2
+++ b/docker/base/Dockerfile.j2
@@ -66,6 +66,7 @@ COPY yum.conf /etc/yum.conf
         'influxdb.repo',
         'kibana.yum.repo',
         'MariaDB.repo',
+        'logstash.repo',
         'opendaylight.repo',
         'td.repo',
     ] %}

--- a/docker/base/logstash.repo
+++ b/docker/base/logstash.repo
@@ -1,0 +1,6 @@
+[logstash-5.x]
+name=Elastic repository for 5.x packages
+baseurl=https://artifacts.elastic.co/packages/5.x/yum
+gpgcheck=1
+gpgkey=https://artifacts.elastic.co/GPG-KEY-elasticsearch
+enabled=1

--- a/docker/logstash/Dockerfile.j2
+++ b/docker/logstash/Dockerfile.j2
@@ -1,0 +1,37 @@
+FROM {{ namespace }}/{{ image_prefix }}base:{{ tag }}
+LABEL maintainer="{{ maintainer }}" name="{{ image_name }}" build-date="{{ build_date }}"
+
+{% block logstash_header %}{% endblock %}
+
+{% import "macros.j2" as macros with context %}
+
+{{ macros.configure_user(name='logstash', shell='/bin/bash', homedir='/usr/share/logstash') }}
+
+{% if install_type == 'binary' %}
+    {% if base_distro in ['centos', 'oraclelinux', 'rhel'] %}
+        {% set logstash_packages = [
+            'logstash',
+            'java-1.8.0-openjdk'
+        ] %}
+        ENV JAVA_HOME /usr/lib/jvm/jre-1.8.0-openjdk/
+    {% elif base_distro in ['debian', 'ubuntu'] %}
+
+        RUN echo '{{ install_type }} not yet available for {{ base_distro }}' \
+            && /bin/false
+    {% endif %}
+
+{% elif install_type == 'source' %}
+    RUN echo '{{ install_type }} not yet available for {{ base_distro }}' \
+    && /bin/false
+
+{% endif %}
+
+{{ macros.install_packages(logstash_packages | customizable("packages")) }}
+COPY extend_start.sh /usr/local/bin/kolla_extend_start
+
+RUN chmod 755 /usr/local/bin/kolla_extend_start
+
+{% block logstash_footer %}{% endblock %}
+{% block footer %}{% endblock %}
+
+USER logstash

--- a/docker/logstash/extend_start.sh
+++ b/docker/logstash/extend_start.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+if [[ ! -d "/var/log/kolla/logstash" ]]; then
+    mkdir -p /var/log/kolla/logstash
+fi
+if [[ $(stat -c %a /var/log/kolla/logstash) != "755" ]]; then
+    chmod 755 /var/log/kolla/logstash
+fi

--- a/docker/monasca/monasca-notification/Dockerfile.j2
+++ b/docker/monasca/monasca-notification/Dockerfile.j2
@@ -19,6 +19,7 @@ ADD monasca-notification-archive /monasca-notification-source
 ] %}
 
 RUN ln -s monasca-notification-source/* monasca-notification \
+    && sed -i 's/no_yaml=False/no_yaml=True/g' /monasca-notification/monasca_notification/config.py \
     && {{ macros.install_pip(monasca_notification_pip_packages | customizable("pip_packages")) }}
 
 {% endif %}

--- a/docker/monasca/monasca-persister/Dockerfile.j2
+++ b/docker/monasca/monasca-persister/Dockerfile.j2
@@ -15,7 +15,9 @@ RUN echo '{{ install_type }} not yet available for {{ base_distro }}' \
 ADD monasca-persister-archive /monasca-persister-source
 
 {% set monasca_persister_pip_packages = [
-    '/monasca-persister'
+    '/monasca-persister',
+    'influxdb',
+    'elasticsearch',
 ] %}
 
 RUN ln -s monasca-persister-source/* monasca-persister \

--- a/docker/monasca/monasca-thresh/Dockerfile.j2
+++ b/docker/monasca/monasca-thresh/Dockerfile.j2
@@ -1,0 +1,72 @@
+FROM {{ namespace }}/{{ image_prefix }}monasca-base:{{ tag }}
+LABEL maintainer="{{ maintainer }}" name="{{ image_name }}" build-date="{{ build_date }}"
+
+{% block monasca_thresh_header %}{% endblock %}
+
+{% import "macros.j2" as macros with context %}
+
+{% if install_type == 'binary' %}
+
+RUN echo '{{ install_type }} not yet available for {{ base_distro }}' \
+    && /bin/false
+
+{% elif install_type == 'source' %}
+
+{% if base_distro in ['centos', 'oraclelinux', 'rhel'] %}
+    {% set monasca_thresh_packages = [
+        'java-1.8.0-openjdk',
+        'maven',
+        'git'
+    ] %}
+{% elif base_distro in ['debian', 'ubuntu'] %}
+    {% set monasca_thresh_packages = [
+        'default-jre',
+        'maven',
+        'git'
+    ] %}
+{% endif %}
+
+{{ macros.install_packages(monasca_thresh_packages | customizable("packages")) }}
+
+# TODO: All we want is the client here..
+{% block storm_version %}
+ENV storm_version=1.1.2
+ENV storm_url=http://www.mirrorservice.org/sites/ftp.apache.org/storm/apache-storm-${storm_version}/apache-storm-${storm_version}.tar.gz
+ENV storm_pkg_sha512sum=4ec7554d4e242c5cfa3b010f63b2ed65866d0768bfa04c7ae87004d21994041ef25b198a236a87f14ac3b36b698f117338080d9b7d9c0f561b7de256bf2e10d2
+{% endblock %}
+
+RUN curl -sSL -o /tmp/storm.tgz ${storm_url} \
+    && echo "${storm_pkg_sha512sum} /tmp/storm.tgz" | sha512sum -c \
+    && mkdir /opt/storm \
+    && tar --strip 1 -xvf /tmp/storm.tgz -C /opt/storm \
+    && rm -f /tmp/storm.tgz
+
+#ADD monasca-common-archive /monasca-common-source
+ENV monasca_common_url=https://github.com/openstack/monasca-common/archive/master.tar.gz
+RUN curl -sSL -o /tmp/monasca-common.tgz ${monasca_common_url} \
+    && mkdir /monasca-common-source \
+    && tar --strip 1 -xvf /tmp/monasca-common.tgz -C /monasca-common-source \
+    && rm -f /tmp/monasca-common.tgz
+
+# Zuul tarball job is borked so use github for now
+ENV monasca_thresh_url=https://github.com/openstack/monasca-thresh/archive/master.tar.gz
+RUN curl -sSL -o /tmp/monasca-thresh.tgz ${monasca_thresh_url} \
+    && mkdir /monasca-thresh-source \
+    && tar --strip 1 -xvf /tmp/monasca-thresh.tgz -C /monasca-thresh-source \
+    && rm -f /tmp/monasca-thresh.tgz
+
+
+{% block monasca_thresh_source_install %}
+# Use this? WORKDIR /usr/local/src/
+RUN cd /monasca-common-source/java \
+    && mvn clean install -DskipTests \
+    && cd /monasca-thresh-source/thresh \
+    && mvn clean package -DskipTests
+{% endblock %}
+
+{% endif %}
+
+{% block monasca_thresh_footer %}{% endblock %}
+{% block footer %}{% endblock %}
+
+USER monasca

--- a/docker/storm/Dockerfile.j2
+++ b/docker/storm/Dockerfile.j2
@@ -1,0 +1,42 @@
+FROM {{ namespace }}/{{ image_prefix }}base:{{ tag }}
+LABEL maintainer="{{ maintainer }}" name="{{ image_name }}" build-date="{{ build_date }}"
+
+{% block storm %}{% endblock %}
+
+{% import "macros.j2" as macros with context %}
+
+{{ macros.configure_user(name='storm', homedir='/opt/storm') }}
+
+{% if base_distro in ['centos', 'oraclelinux', 'rhel'] %}
+    {% set storm_packages = [
+        'java-1.8.0-openjdk',
+    ] %}
+{% elif base_distro in ['debian', 'ubuntu'] %}
+    {% set storm_packages = [
+        'default-jre',
+    ] %}
+{% endif %}
+
+{{ macros.install_packages(storm_packages | customizable("packages")) }}
+
+{% block storm_version %}
+ENV storm_version=1.1.2
+ENV storm_url=http://www.mirrorservice.org/sites/ftp.apache.org/storm/apache-storm-${storm_version}/apache-storm-${storm_version}.tar.gz
+ENV storm_pkg_sha512sum=4ec7554d4e242c5cfa3b010f63b2ed65866d0768bfa04c7ae87004d21994041ef25b198a236a87f14ac3b36b698f117338080d9b7d9c0f561b7de256bf2e10d2
+{% endblock %}
+
+{% block storm_install %}
+RUN curl -sSL -o /tmp/storm.tgz ${storm_url} \
+    && echo "${storm_pkg_sha512sum} /tmp/storm.tgz" | sha512sum -c \
+    && tar --strip 1 -xvf /tmp/storm.tgz -C /opt/storm \
+    && rm -f /tmp/storm.tgz
+
+{% endblock %}
+
+COPY extend_start.sh /usr/local/bin/kolla_extend_start
+RUN chmod 755 /usr/local/bin/kolla_extend_start
+
+{% block storm_footer %}{% endblock %}
+{% block footer %}{% endblock %}
+
+USER storm

--- a/docker/storm/extend_start.sh
+++ b/docker/storm/extend_start.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# Create log directory, with appropriate permissions
+if [[ ! -d "/var/log/kolla/storm" ]]; then
+    mkdir -p /var/log/kolla/storm
+fi
+if [[ $(stat -c %a /var/log/kolla/storm) != "755" ]]; then
+    chmod 755 /var/log/kolla/storm
+fi

--- a/kolla/common/config.py
+++ b/kolla/common/config.py
@@ -65,6 +65,7 @@ _PROFILE_OPTS = [
                     'keepalived',
                     'kibana',
                     'kolla-toolbox',
+                    'logstash',
                     'mariadb',
                     'memcached',
                     'mongodb',
@@ -941,6 +942,10 @@ USERS = {
     'fluentd-user': {
         'uid': 42474,
         'gid': 42474,
+    },
+    'logstash-user': {
+        'uid': 42478,
+        'gid': 42478,
     }
 }
 

--- a/kolla/common/config.py
+++ b/kolla/common/config.py
@@ -75,6 +75,7 @@ _PROFILE_OPTS = [
                     'rabbitmq',
                     'redis',
                     'skydive',
+                    'storm',
                     'tgtd',
                 ],
                 help='Infra images'),
@@ -122,6 +123,7 @@ _PROFILE_OPTS = [
                     'searchlight',
                     'senlin',
                     'solum',
+                    'storm',
                     'tacker',
                     'telegraf',
                     'trove',
@@ -946,6 +948,10 @@ USERS = {
     'logstash-user': {
         'uid': 42478,
         'gid': 42478,
+    },
+    'storm-user': {
+        'uid': 42479,
+        'gid': 42479,
     }
 }
 

--- a/kolla/common/config.py
+++ b/kolla/common/config.py
@@ -497,6 +497,10 @@ SOURCES = {
         'type': 'url',
         'location': ('$tarballs_base/monasca-statsd/'
                      'monasca-statsd-1.7.0.tar.gz')},
+    'monasca-common': {
+        'type': 'url',
+        'location': ('$tarballs_base/monasca-common/'
+                     'monasca-common-master.tar.gz')},
     'murano-base': {
         'type': 'url',
         'location': ('$tarballs_base/murano/'

--- a/kolla/common/config.py
+++ b/kolla/common/config.py
@@ -488,7 +488,7 @@ SOURCES = {
     'monasca-notification': {
         'type': 'url',
         'location': ('$tarballs_base/monasca-notification/'
-                     'monasca-notification-1.10.1.tar.gz')},
+                     'monasca-notification-1.12.0.tar.gz')},
     'monasca-persister': {
         'type': 'url',
         'location': ('$tarballs_base/monasca-persister/'

--- a/releasenotes/notes/add-apache-storm-927c5318d91b5db3.yaml
+++ b/releasenotes/notes/add-apache-storm-927c5318d91b5db3.yaml
@@ -1,0 +1,3 @@
+---
+features:
+  - Add support for building an Apache Storm image.

--- a/releasenotes/notes/add-logstash-27da5de156efb943.yaml
+++ b/releasenotes/notes/add-logstash-27da5de156efb943.yaml
@@ -1,0 +1,3 @@
+---
+features:
+  - Add Logstash support for RHEL/Centos.

--- a/releasenotes/notes/add-monasca-thresh-f3df34dee9eee562.yaml
+++ b/releasenotes/notes/add-monasca-thresh-f3df34dee9eee562.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Add Monasca Thresh, an Apache Storm topology for alerting in Monasca.


### PR DESCRIPTION
Centos uses Elasticsearch 2.x. According to the support matrix [1]
that should be compatable with LogStash version up to 5.6.x, so
that's what we install here.

[1] https://www.elastic.co/support/matrix#matrix_compatibility

Change-Id: I4e2422d1cd2ae4c1f4aa63e8e543e725a1dc840c

Conflicts:
	docker/base/Dockerfile.j2
	kolla/common/config.py