### PR TITLE
copy iPXE NBP to /tftpboot during PXE bootstrap

### DIFF
--- a/docker/ironic/ironic-pxe/extend_start.sh
+++ b/docker/ironic/ironic-pxe/extend_start.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 
-# Bootstrap and exit if KOLLA_BOOTSTRAP variable is set. This catches all cases
-# of the KOLLA_BOOTSTRAP variable being set, including empty.
-if [[ "${!KOLLA_BOOTSTRAP[@]}" ]]; then
+
+function prepare_pxe {
     chown -R ironic: /tftpboot
     for pxe_file in /var/lib/tftpboot/pxelinux.0 /var/lib/tftpboot/chain.c32 /usr/lib/syslinux/pxelinux.0 \
                     /usr/lib/syslinux/chain.c32 /usr/lib/PXELINUX/pxelinux.0 \
@@ -11,6 +10,21 @@ if [[ "${!KOLLA_BOOTSTRAP[@]}" ]]; then
             cp "$pxe_file" /tftpboot
         fi
     done
+}
+
+function prepare_ipxe {
+    if [[ "${KOLLA_BASE_DISTRO}" =~ debian|ubuntu ]]; then
+        cp /usr/lib/ipxe/{undionly.kpxe,ipxe.efi} /tftpboot
+    elif [[ "${KOLLA_BASE_DISTRO}" =~ centos|oraclelinux|rhel ]]; then
+        cp /usr/share/ipxe/{undionly.kpxe,ipxe.efi} /tftpboot
+    fi
+}
+
+# Bootstrap and exit if KOLLA_BOOTSTRAP variable is set. This catches all cases
+# of the KOLLA_BOOTSTRAP variable being set, including empty.
+if [[ "${!KOLLA_BOOTSTRAP[@]}" ]]; then
+    prepare_pxe
+    prepare_ipxe
     exit 0
 fi
 

--- a/releasenotes/notes/support-ipxe-chainload-273d55741a83a2a7.yaml
+++ b/releasenotes/notes/support-ipxe-chainload-273d55741a83a2a7.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - Copy iPXE images to TFTP root during ironic_pxe bootstrap. This
+    allows you to chainload iPXE from a PXE environment.


### PR DESCRIPTION
This allows you to chainload iPXE from a standard PXE
environment.

As the PXE container already has apache installed, we
now have everything we need to support iPXE booting.

Change-Id: Ide32dc1910e9f8b3ff875238648726f719e271b2
Implements: blueprint ironic-ipxe
(cherry picked from commit d63930e3dd80b313822e9f65a76b9c338ef9e389)