### PR TITLE
Bump Monasca Fluentd plugin version

### DIFF
--- a/docker/fluentd/Dockerfile.j2
+++ b/docker/fluentd/Dockerfile.j2
@@ -75,7 +75,7 @@ RUN chmod 755 /usr/local/bin/kolla_extend_start
 {{ macros.install_fluent_plugins(fluentd_plugins | customizable("plugins")) }}
 
 # Build and install Fluentd output plugin for Monasca Log API
-ARG monasca_output_plugin_tag=0.0.1
+ARG monasca_output_plugin_tag=0.1.0
 ARG monasca_output_plugin_url=https://github.com/monasca/fluentd-monasca/archive/$monasca_output_plugin_tag.tar.gz
 ADD $monasca_output_plugin_url /tmp/fluentd-monasca.tar.gz
 RUN tar -xvf /tmp/fluentd-monasca.tar.gz -C /tmp \


### PR DESCRIPTION
Bump version to include support for setting log message field
name.

Change-Id: Ib3953b49247bb36ac8ce25578c05c6bcb2a1905a
Partial-Bug: #1830184
(cherry picked from commit 529d2b54ed6f04df45732fccfdb9e2f0214d65c1)