### PR TITLE
Bump Monasca Fluentd output plugin

### DIFF
--- a/docker/fluentd/Dockerfile.j2
+++ b/docker/fluentd/Dockerfile.j2
@@ -75,7 +75,7 @@ RUN chmod 755 /usr/local/bin/kolla_extend_start
 {{ macros.install_fluent_plugins(fluentd_plugins | customizable("plugins")) }}
 
 # Build and install Fluentd output plugin for Monasca Log API
-ARG monasca_output_plugin_tag=0.1.0
+ARG monasca_output_plugin_tag=0.1.1
 ARG monasca_output_plugin_url=https://github.com/monasca/fluentd-monasca/archive/$monasca_output_plugin_tag.tar.gz
 ADD $monasca_output_plugin_url /tmp/fluentd-monasca.tar.gz
 RUN tar -xvf /tmp/fluentd-monasca.tar.gz -C /tmp \


### PR DESCRIPTION
This resolves an issue where the previous version of the plugin
would fail to re-send buffered logs if a post to the Monasca Log
API failed. With this new version of the plugin, logs are correctly
buffered and resent.

Change-Id: Ic1d93a8ea5f2571edfacf50809d51a8b77959a73