### PR TITLE
Port all rocky patches to stable/stein

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,34 @@
+---
+language: python
+python: "2.7"
+
+# Run jobs in VMs - sudo is required by ansible tests.
+sudo: required
+
+# Install ansible
+addons:
+  apt:
+    packages:
+      - gcc
+      - python-apt
+      - python-virtualenv
+      - realpath
+
+# Create a build matrix for the different test jobs.
+env:
+  matrix:
+    # Run python style checks.
+    - TOX_ENV=pep8
+    # Build documentation.
+    - TOX_ENV=docs
+    # Run python2.7 unit tests.
+    - TOX_ENV=py27
+
+install:
+  # Install tox in a virtualenv to ensure we have an up to date version.
+  - pip install -U pip
+  - pip install tox
+
+script:
+  # Run the tox environment.
+  - tox -e ${TOX_ENV}

--- a/docker/fluentd/Dockerfile.j2
+++ b/docker/fluentd/Dockerfile.j2
@@ -75,7 +75,7 @@ RUN chmod 755 /usr/local/bin/kolla_extend_start
 {{ macros.install_fluent_plugins(fluentd_plugins | customizable("plugins")) }}
 
 # Build and install Fluentd output plugin for Monasca Log API
-ARG monasca_output_plugin_tag=0.1.0
+ARG monasca_output_plugin_tag=0.1.1
 ARG monasca_output_plugin_url=https://github.com/monasca/fluentd-monasca/archive/$monasca_output_plugin_tag.tar.gz
 ADD $monasca_output_plugin_url /tmp/fluentd-monasca.tar.gz
 RUN tar -xvf /tmp/fluentd-monasca.tar.gz -C /tmp \


### PR DESCRIPTION
from rebase onto stable/rocky:

pick 71076aac0 Bump up Prometheus and components versions
pick 5d2b2d726 Add travis.yml
pick b542d7b15 Fix doc8 issues
pick 9609685ef Bump Monasca Fluentd output plugin#


don't pick: 
-----------
pick 71076aac0 Bump up Prometheus and components versions: upstream change in 8.0.0.0rc1, see: https://github.com/openstack/kolla/commit/5e89fbd3b7c159d249ab806830f466f5522f8e87
pick b542d7b15 Fix doc8 issues: wording has changed

pick:
-----
pick 5d2b2d726 Add travis.yml
pick 9609685ef Bump Monasca Fluentd output plugin# : waiting on https://review.opendev.org/#/c/670992/
