### PR TITLE
Fix CI failures (ODL and searchlight)

### DIFF
--- a/docker/base/opendaylight.repo
+++ b/docker/base/opendaylight.repo
@@ -1,5 +1,5 @@
 [opendaylight]
-name=CentOS CBS OpenDaylight Release Repository
-baseurl=http://cbs.centos.org/repos/nfv7-opendaylight-6-release/x86_64/os/
+name=OpenDaylight Carbon
+baseurl=https://nexus.opendaylight.org/content/repositories/opendaylight-carbon-epel-7-x86_64-devel/
 enabled=1
 gpgcheck=0

--- a/docker/horizon/Dockerfile.j2
+++ b/docker/horizon/Dockerfile.j2
@@ -130,12 +130,14 @@ ADD plugins-archive /
     '/plugins/*'
 ] %}
 
+# NOTE(hrw) searchlight-ui was not released in Rocky, we used 'master' and now it fails due to py2 != py3
 RUN ln -s horizon-source/* horizon \
     && {{ macros.install_pip(horizon_pip_packages | customizable("pip_packages")) }} \
     && mkdir -p /etc/openstack-dashboard \
     && cp -r /horizon/openstack_dashboard/conf/* /etc/openstack-dashboard/ \
     && cp /horizon/openstack_dashboard/local/local_settings.py.example /etc/openstack-dashboard/local_settings \
     && cp /horizon/manage.py /var/lib/kolla/venv/bin/manage.py \
+    && rm -rf /plugins/searchlight-ui* \
     && if [ "$(ls /plugins)" ]; then \
            {{ macros.install_pip(horizon_plugins_pip_packages) }}; \
        fi \

--- a/kolla/image/build.py
+++ b/kolla/image/build.py
@@ -96,6 +96,7 @@ SKIPPED_IMAGES = {
     ],
     'centos+source': [
         "ovsdpdk",
+        "searchlight-base",
         # TODO(jeffrey4l): remove tripleo-ui when following bug is fixed
         # https://bugs.launchpad.net/tripleo/+bug/1744215
         "tripleo-ui"
@@ -133,6 +134,7 @@ SKIPPED_IMAGES = {
     'ubuntu+source': [
         # There is no qdrouterd package for ubuntu bionic
         "qdrouterd",
+        "searchlight-base",
         # TODO(jeffrey4l): remove tripleo-ui when following bug is fixed
         # https://bugs.launchpad.net/tripleo/+bug/1744215
         "tripleo-ui"
@@ -168,6 +170,7 @@ SKIPPED_IMAGES = {
     ],
     'debian+source': [
         "sensu-base",
+        "searchlight-base",
         "tripleo-ui"
     ],
     'oraclelinux+binary': [


### PR DESCRIPTION
searchlight: do not try to build it

Searchlight did not had release during Rocky cycle. So we left using
'master' tarball. Now Python 2.7 support got removed in Ussuri and our
CI builds fail.

So searchlight is added into SKIPPED_IMAGES and it's plugin is removed
from horizon image.

Change ODL repo to nexus.opendaylight.org

(cherry picked from commit 939a56035b8f15b74dff2d68154963735b0f73b4)
(cherry picked from commit 5a08221cc4270dec3af5ff613731cc7be7576124)

Change-Id: Ib290fb2ec80f408c9d1e134595a5bb7ace922952
(cherry picked from commit 9cf48143a10e51e0bbb895140bf739f0cb383a6f)