### PR TITLE
Install Monasca plugin for Grafana by default (#39)

### DIFF
--- a/docker/monasca/monasca-grafana/Dockerfile.j2
+++ b/docker/monasca/monasca-grafana/Dockerfile.j2
@@ -77,6 +77,15 @@ RUN grafana-cli plugins install monasca-datasource \
     && chmod 440 /etc/sudoers.d/kolla_grafana_sudoers \
     && chmod 755 /usr/local/bin/kolla_extend_start
 
+RUN mkdir -p /var/lib/grafana/plugins/monasca-grafana \
+    && curl -Lo tmp.tgz https://github.com/monasca/monasca-grafana/tarball/master \
+    && tar zxvf tmp.tgz -C /var/lib/grafana/plugins/monasca-grafana --strip-components=1 \
+    && rm tmp.tgz \
+    && npm install -g grunt \
+    && cd /var/lib/grafana/plugins/monasca-grafana \
+    && npm install \
+    && grunt
+
 {% block monasca_grafana_footer %}{% endblock %}
 {% block footer %}{% endblock %}
 


### PR DESCRIPTION
Backporting for Stein. Upstream here: https://review.opendev.org/#/c/676185/
Change-Id: I472af9ec8cee3462beb5aca04ea6171b79933abe