### PR TITLE
Train/monasca centos8

### DIFF
--- a/docker/cyborg/cyborg-api/Dockerfile.j2
+++ b/docker/cyborg/cyborg-api/Dockerfile.j2
@@ -13,8 +13,12 @@ RUN echo '{{ install_type }} not yet available for {{ base_distro }}'  \
     {% if base_package_type == 'rpm' %}
         {% set cyborg_api_packages = [
             'mod_ssl',
-            'mod_wsgi'
         ] %}
+        {% if distro_python_version.startswith('3') %}
+            {% set cyborg_api_packages = cyborg_api_packages + ['python3-mod_wsgi'] %}
+        {% else %}
+            {% set cyborg_api_packages = cyborg_api_packages + ['mod_wsgi'] %}
+        {% endif %}
     {% elif base_package_type == 'deb' %}
         {% set cyborg_api_packages = [
             'apache2',

--- a/docker/kolla-toolbox/Dockerfile.j2
+++ b/docker/kolla-toolbox/Dockerfile.j2
@@ -78,7 +78,9 @@ LABEL maintainer="{{ maintainer }}" name="{{ image_name }}" build-date="{{ build
         'virtualenv'
     ] %}
 
-RUN {{ macros.install_pip(kolla_toolbox_pip_virtualenv_packages | customizable("pip_virtualenv_packages"), constraints=false) }} \
+RUN mkdir -p /requirements \
+    && curl -sSL -o /requirements/upper-constraints.txt https://releases.openstack.org/constraints/upper/{{ openstack_release }} \
+    && {{ macros.install_pip(kolla_toolbox_pip_virtualenv_packages | customizable("pip_virtualenv_packages")) }} \
     && virtualenv --system-site-packages {{ virtualenv_path }}
 
 ENV PATH {{ virtualenv_path }}/bin:$PATH
@@ -97,9 +99,7 @@ ENV PATH {{ virtualenv_path }}/bin:$PATH
         'shade'
     ] %}
 
-RUN mkdir -p /requirements \
-    && curl -sSL -o /requirements/upper-constraints.txt https://releases.openstack.org/constraints/upper/{{ openstack_release }} \
-    && {{ macros.install_pip(kolla_toolbox_pip_packages | customizable("pip_packages")) }} \
+RUN {{ macros.install_pip(kolla_toolbox_pip_packages | customizable("pip_packages")) }} \
     && mkdir -p /etc/ansible /usr/share/ansible \
     && echo 'localhost ansible_connection=local ansible_python_interpreter={{ virtualenv_path }}/bin/python' > /etc/ansible/hosts \
     && sed -i 's|  "identity_api_version": "2.0",|  "identity_api_version": "3",|' {{ os_client_config }}

--- a/docker/logstash6/Dockerfile.j2
+++ b/docker/logstash6/Dockerfile.j2
@@ -1,0 +1,29 @@
+FROM {{ namespace }}/{{ image_prefix }}base:{{ tag }}
+{% block labels %}
+LABEL maintainer="{{ maintainer }}" name="{{ image_name }}" build-date="{{ build_date }}"
+{% endblock %}
+
+{% block logstash_header %}{% endblock %}
+
+{% import "macros.j2" as macros with context %}
+
+{{ macros.configure_user(name='logstash', shell='/bin/bash', homedir='/usr/share/logstash') }}
+
+ENV JAVA_HOME /usr/lib/jvm/jre-11-openjdk/
+
+{% set logstash_packages = [
+    'java-11-openjdk-headless',
+    'logstash-oss',
+] %}
+
+COPY elasticsearch.repo /etc/yum.repos.d/
+
+{{ macros.install_packages(logstash_packages | customizable("packages")) }}
+COPY extend_start.sh /usr/local/bin/kolla_extend_start
+
+RUN chmod 755 /usr/local/bin/kolla_extend_start
+
+{% block logstash_footer %}{% endblock %}
+{% block footer %}{% endblock %}
+
+USER logstash

--- a/docker/logstash6/elasticsearch.repo
+++ b/docker/logstash6/elasticsearch.repo
@@ -1,0 +1,6 @@
+[elasticsearch-kibana-logstash-6.x]
+name=ELK repository for 6.x packages
+baseurl=https://artifacts.elastic.co/packages/oss-6.x/yum
+gpgcheck=1
+gpgkey=https://artifacts.elastic.co/GPG-KEY-elasticsearch
+enabled=1

--- a/docker/logstash6/extend_start.sh
+++ b/docker/logstash6/extend_start.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+if [[ ! -d "/var/log/kolla/logstash" ]]; then
+    mkdir -p /var/log/kolla/logstash
+fi
+if [[ $(stat -c %a /var/log/kolla/logstash) != "755" ]]; then
+    chmod 755 /var/log/kolla/logstash
+fi

--- a/docker/storm/Dockerfile.j2
+++ b/docker/storm/Dockerfile.j2
@@ -40,6 +40,13 @@ RUN curl -sSL -o /tmp/storm.tgz ${storm_url} \
 
 {% endblock %}
 
+{% block storm_python_version %}
+# NOTE(dszumski): Storm needs to be told where the Py3 interpreter lives
+{% if distro_python_version.startswith('3') %}
+ENV PYTHON={{ '/usr/bin/python' ~ distro_python_version }}
+{% endif %}
+{% endblock %}
+
 COPY extend_start.sh /usr/local/bin/kolla_extend_start
 RUN chmod 755 /usr/local/bin/kolla_extend_start
 

--- a/kolla/common/config.py
+++ b/kolla/common/config.py
@@ -315,11 +315,11 @@ SOURCES = {
     'aodh-base': {
         'type': 'url',
         'location': ('$tarballs_base/aodh/'
-                     'aodh-9.0.0.tar.gz')},
+                     'aodh-9.0.1.tar.gz')},
     'barbican-base': {
         'type': 'url',
         'location': ('$tarballs_base/barbican/'
-                     'barbican-9.0.0.tar.gz')},
+                     'barbican-9.0.1.tar.gz')},
     'bifrost-base': {
         'type': 'url',
         'location': ('$tarballs_base/bifrost/'
@@ -331,7 +331,7 @@ SOURCES = {
     'ceilometer-base': {
         'type': 'url',
         'location': ('$tarballs_base/ceilometer/'
-                     'ceilometer-13.1.0.tar.gz')},
+                     'ceilometer-13.1.1.tar.gz')},
     'ceilometer-base-plugin-panko': {
         'type': 'url',
         'location': ('$tarballs_base/panko/'
@@ -339,7 +339,7 @@ SOURCES = {
     'cinder-base': {
         'type': 'url',
         'location': ('$tarballs_base/cinder/'
-                     'cinder-15.1.0.tar.gz')},
+                     'cinder-15.2.0.tar.gz')},
     'congress-base': {
         'type': 'url',
         'location': ('$tarballs_base/congress/'
@@ -355,7 +355,7 @@ SOURCES = {
     'designate-base': {
         'type': 'url',
         'location': ('$tarballs_base/designate/'
-                     'designate-9.0.0.tar.gz')},
+                     'designate-9.0.1.tar.gz')},
     'dragonflow-base': {
         'type': 'url',
         'location': ('$tarballs_base/dragonflow/'
@@ -375,7 +375,7 @@ SOURCES = {
     'glance-base': {
         'type': 'url',
         'location': ('$tarballs_base/glance/'
-                     'glance-19.0.2.tar.gz')},
+                     'glance-19.0.3.tar.gz')},
     'gnocchi-base': {
         'type': 'git',
         'reference': '4.3.4',
@@ -388,7 +388,7 @@ SOURCES = {
     'horizon': {
         'type': 'url',
         'location': ('$tarballs_base/horizon/'
-                     'horizon-16.1.0.tar.gz')},
+                     'horizon-16.2.0.tar.gz')},
     'horizon-plugin-blazar-dashboard': {
         'type': 'url',
         'location': ('$tarballs_base/blazar-dashboard/'
@@ -404,7 +404,7 @@ SOURCES = {
     'horizon-plugin-designate-dashboard': {
         'type': 'url',
         'location': ('$tarballs_base/designate-dashboard/'
-                     'designate-dashboard-9.0.0.tar.gz')},
+                     'designate-dashboard-9.0.1.tar.gz')},
     'horizon-plugin-fwaas-dashboard': {
         'type': 'url',
         'location': ('$tarballs_base/neutron-fwaas-dashboard/'
@@ -416,7 +416,7 @@ SOURCES = {
     'horizon-plugin-heat-dashboard': {
         'type': 'url',
         'location': ('$tarballs_base/heat-dashboard/'
-                     'heat-dashboard-2.0.0.tar.gz')},
+                     'heat-dashboard-2.0.1.tar.gz')},
     'horizon-plugin-ironic-ui': {
         'type': 'url',
         'location': ('$tarballs_base/ironic-ui/'
@@ -432,7 +432,7 @@ SOURCES = {
     'horizon-plugin-manila-ui': {
         'type': 'url',
         'location': ('$tarballs_base/manila-ui/'
-                     'manila-ui-2.19.1.tar.gz')},
+                     'manila-ui-2.19.2.tar.gz')},
     'horizon-plugin-masakari-dashboard': {
         'type': 'url',
         'location': ('$tarballs_base/masakari-dashboard/'
@@ -444,7 +444,7 @@ SOURCES = {
     'horizon-plugin-monasca-ui': {
         'type': 'url',
         'location': ('$tarballs_base/monasca-ui/'
-                     'monasca-ui-1.17.0.tar.gz')},
+                     'monasca-ui-1.17.1.tar.gz')},
     'horizon-plugin-murano-dashboard': {
         'type': 'url',
         'location': ('$tarballs_base/murano-dashboard/'
@@ -452,7 +452,7 @@ SOURCES = {
     'horizon-plugin-neutron-vpnaas-dashboard': {
         'type': 'url',
         'location': ('$tarballs_base/neutron-vpnaas-dashboard/'
-                     'neutron-vpnaas-dashboard-1.6.0.tar.gz')},
+                     'neutron-vpnaas-dashboard-1.6.1.tar.gz')},
     'horizon-plugin-octavia-dashboard': {
         'type': 'url',
         'location': ('$tarballs_base/octavia-dashboard/'
@@ -464,7 +464,7 @@ SOURCES = {
     'horizon-plugin-sahara-dashboard': {
         'type': 'url',
         'location': ('$tarballs_base/sahara-dashboard/'
-                     'sahara-dashboard-11.0.0.tar.gz')},
+                     'sahara-dashboard-11.0.1.tar.gz')},
     'horizon-plugin-searchlight-ui': {
         'type': 'url',
         'location': ('$tarballs_base/searchlight-ui/'
@@ -476,7 +476,7 @@ SOURCES = {
     'horizon-plugin-solum-dashboard': {
         'type': 'url',
         'location': ('$tarballs_base/solum-dashboard/'
-                     'solum-dashboard-3.0.0.tar.gz')},
+                     'solum-dashboard-3.0.1.tar.gz')},
     'horizon-plugin-tacker-dashboard': {
         'type': 'url',
         'location': ('$tarballs_base/tacker-horizon/'
@@ -500,7 +500,7 @@ SOURCES = {
     'horizon-plugin-zun-ui': {
         'type': 'url',
         'location': ('$tarballs_base/zun-ui/'
-                     'zun-ui-4.0.0.tar.gz')},
+                     'zun-ui-4.0.1.tar.gz')},
     'ironic-base': {
         'type': 'url',
         'location': ('$tarballs_base/ironic/'
@@ -508,7 +508,7 @@ SOURCES = {
     'ironic-inspector': {
         'type': 'url',
         'location': ('$tarballs_base/ironic-inspector/'
-                     'ironic-inspector-9.2.2.tar.gz')},
+                     'ironic-inspector-9.2.3.tar.gz')},
     'karbor-base': {
         'type': 'url',
         'location': ('$tarballs_base/karbor/'
@@ -524,15 +524,15 @@ SOURCES = {
     'kuryr-libnetwork': {
         'type': 'url',
         'location': ('$tarballs_base/kuryr-libnetwork/'
-                     'kuryr-libnetwork-4.0.0.tar.gz')},
+                     'kuryr-libnetwork-4.0.1.tar.gz')},
     'magnum-base': {
         'type': 'url',
         'location': ('$tarballs_base/magnum/'
-                     'magnum-9.3.0.tar.gz')},
+                     'magnum-9.4.0.tar.gz')},
     'manila-base': {
         'type': 'url',
         'location': ('$tarballs_base/manila/'
-                     'manila-9.1.2.tar.gz')},
+                     'manila-9.1.3.tar.gz')},
     'masakari-base': {
         'type': 'url',
         'location': ('$tarballs_base/masakari/'
@@ -548,19 +548,19 @@ SOURCES = {
     'mistral-base-plugin-tacker': {
         'type': 'url',
         'location': ('$tarballs_base/tacker/'
-                     'tacker-2.0.0.tar.gz')},
+                     'tacker-2.0.1.tar.gz')},
     'monasca-agent': {
         'type': 'url',
         'location': ('$tarballs_base/monasca-agent/'
-                     'monasca-agent-2.11.0.tar.gz')},
+                     'monasca-agent-2.12.0.tar.gz')},
     'monasca-api': {
         'type': 'url',
         'location': ('$tarballs_base/monasca-api/'
-                     'monasca-api-3.1.0.tar.gz')},
+                     'monasca-api-3.2.0.tar.gz')},
     'monasca-log-api': {
         'type': 'url',
         'location': ('$tarballs_base/monasca-log-api/'
-                     'monasca-log-api-2.10.0.tar.gz')},
+                     'monasca-log-api-2.11.0.tar.gz')},
     'monasca-notification': {
         'type': 'url',
         'location': ('$tarballs_base/monasca-notification/'
@@ -585,7 +585,7 @@ SOURCES = {
     'murano-base': {
         'type': 'url',
         'location': ('$tarballs_base/murano/'
-                     'murano-8.0.0.tar.gz')},
+                     'murano-8.1.0.tar.gz')},
     'neutron-base': {
         'type': 'url',
         'location': ('$tarballs_base/neutron/'
@@ -661,7 +661,7 @@ SOURCES = {
     'nova-base': {
         'type': 'url',
         'location': ('$tarballs_base/nova/'
-                     'nova-20.2.0.tar.gz')},
+                     'nova-20.3.0.tar.gz')},
     'nova-base-plugin-blazar': {
         'type': 'url',
         'location': ('$tarballs_base/blazar-nova/'
@@ -793,7 +793,7 @@ SOURCES = {
     'sahara-base-plugin-mapr': {
         'type': 'url',
         'location': ('$tarballs_base/sahara-plugin-mapr/'
-                     'sahara-plugin-mapr-2.0.0.tar.gz')},
+                     'sahara-plugin-mapr-2.0.1.tar.gz')},
     'sahara-base-plugin-spark': {
         'type': 'url',
         'location': ('$tarballs_base/sahara-plugin-spark/'
@@ -825,7 +825,7 @@ SOURCES = {
     'tacker-base': {
         'type': 'url',
         'location': ('$tarballs_base/tacker/'
-                     'tacker-2.0.0.tar.gz')},
+                     'tacker-2.0.1.tar.gz')},
     'tacker-base-plugin-networking-sfc': {
         'type': 'url',
         'location': ('$tarballs_base/networking-sfc/'
@@ -841,11 +841,11 @@ SOURCES = {
     'trove-base': {
         'type': 'url',
         'location': ('$tarballs_base/trove/'
-                     'trove-12.0.0.tar.gz')},
+                     'trove-12.1.0.tar.gz')},
     'vitrage-base': {
         'type': 'url',
         'location': ('$tarballs_base/vitrage/'
-                     'vitrage-5.0.1.tar.gz')},
+                     'vitrage-5.0.2.tar.gz')},
     'vmtp': {
         'type': 'url',
         'location': ('$tarballs_base/vmtp/'
@@ -853,15 +853,15 @@ SOURCES = {
     'watcher-base': {
         'type': 'url',
         'location': ('$tarballs_base/watcher/'
-                     'python-watcher-3.0.0.tar.gz')},
+                     'python-watcher-3.0.1.tar.gz')},
     'zaqar-base': {
         'type': 'url',
         'location': ('$tarballs_base/zaqar/'
-                     'zaqar-9.0.0.tar.gz')},
+                     'zaqar-9.0.1.tar.gz')},
     'zun-base': {
         'type': 'url',
         'location': ('$tarballs_base/zun/'
-                     'zun-4.0.0.tar.gz')}
+                     'zun-4.0.1.tar.gz')}
 }
 
 

--- a/kolla/common/config.py
+++ b/kolla/common/config.py
@@ -552,7 +552,7 @@ SOURCES = {
     'monasca-agent': {
         'type': 'url',
         'location': ('$tarballs_base/monasca-agent/'
-                     'monasca-agent-2.12.0.tar.gz')},
+                     'monasca-agent-2.12.1.tar.gz')},
     'monasca-api': {
         'type': 'url',
         'location': ('$tarballs_base/monasca-api/'

--- a/kolla/image/build.py
+++ b/kolla/image/build.py
@@ -175,6 +175,7 @@ UNBUILDABLE_IMAGES = {
                          # Debian 'buster'
         "cyborg-base",
         "elasticsearch6",   # Only required for CentOS 8 migration.
+        "logstash6",        # Only required for CentOS 8 migration.
         "kibana6",          # Only required for CentOS 8 migration.
         "monasca-grafana",  # FIXME(hrw): some ssl issues to fix
         "mongodb",
@@ -188,6 +189,7 @@ UNBUILDABLE_IMAGES = {
     'ubuntu': {
         "cyborg-base",
         "elasticsearch6",   # Only required for CentOS 8 migration.
+        "logstash6",        # Only required for CentOS 8 migration.
         "kibana6",          # Only required for CentOS 8 migration.
         "qdrouterd",  # There is no qdrouterd package for ubuntu bionic
         "rabbitmq-3.7.24",  # Required only for CentOS 7 to 8 migration

--- a/kolla/image/build.py
+++ b/kolla/image/build.py
@@ -167,6 +167,7 @@ UNBUILDABLE_IMAGES = {
 
     'centos8+source': {
         "cyborg-agent",          # opae-sdk does not support CentOS 8
+        "masakari-monitors",     # python-libvirt===5.7.0 fails
     },
 
     'debian': {

--- a/releasenotes/notes/add-logstash6-7418a88dc5cb88eb.yaml
+++ b/releasenotes/notes/add-logstash6-7418a88dc5cb88eb.yaml
@@ -1,0 +1,5 @@
+---
+upgrade:
+  - |
+    The Logstash image has been upgraded from Logstash 2 to Logstash 6 for
+    Centos 7 and Centos 8 only.

--- a/releasenotes/notes/fix-loading-of-storm-in-centos8-containers-86b38c9166ceb0dd.yaml
+++ b/releasenotes/notes/fix-loading-of-storm-in-centos8-containers-86b38c9166ceb0dd.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixes an issue with loading Storm and Monasca Thresh when using
+    Centos8 containers.

--- a/releasenotes/notes/fix-monasca-agent-stats-cc728000b6b05362.yaml
+++ b/releasenotes/notes/fix-monasca-agent-stats-cc728000b6b05362.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fixes a bug in Monasca Agent Statsd which causes it to fail under Python 3.

--- a/tests/playbooks/pre.yml
+++ b/tests/playbooks/pre.yml
@@ -18,7 +18,49 @@
         path: "{{ kolla_build_logs_dir }}"
         state: directory
 
+    - block:
+
+        - name: Ensure yum-utils is installed
+          # NOTE(mgoddard): The CentOS image used in CI has epel-release installed,
+          # but the configure-mirrors role used by Zuul disables epel. Since we
+          # install epel-release and expect epel to be enabled, enable it here.
+          package:
+            name: yum-utils
+            state: present
+
+        - name: Enable the EPEL repository
+          command: yum-config-manager --enable epel
+
+      become: true
+      when:
+        - ansible_os_family == "RedHat"
+
+    - name: Install Python2 modules
+      become: true
+      package:
+        name:
+          - python-pip
+          - python-setuptools
+          - python-wheel
+          - python-virtualenv
+
+    - name: Install virtualenv on Debian systems
+      # NOTE(hrw): On RedHat systems it is part of python3-virtualenv
+      package:
+        name:
+          - virtualenv
+      become: true
+      when:
+        ansible_os_family == "Debian"
+
+    - name: Upgrade pip to latest version
+      # NOTE(mnasiadka): pip 8.x delivered with EPEL has problems installing
+      # zipp and configparser
+      become: true
+      command: "pip install --upgrade pip"
+
     - name: Ensure tox is installed
       pip:
         name: tox
+        virtualenv: "{{ ansible_user_dir }}/tox-venv"
       become: true

--- a/tests/playbooks/run.yml
+++ b/tests/playbooks/run.yml
@@ -33,6 +33,6 @@
         dest: /etc/kolla/template_overrides.j2
 
     - name: Run tox
-      command: tox -e {{ action }}-{{ base_distro }}{{ base_tag | default('') }}-{{ install_type }}
+      command: "{{ ansible_user_dir }}/tox-venv/bin/tox -e {{ action }}-{{ base_distro }}{{ base_tag | default('') }}-{{ install_type }}"
       args:
         chdir: "{{ zuul.project.src_dir }}"

--- a/tests/templates/template_overrides.j2
+++ b/tests/templates/template_overrides.j2
@@ -6,6 +6,7 @@
 
 ENV PIP_INDEX_URL {{ nodepool_pypi_mirror }}
 ENV PIP_TRUSTED_HOST {{ nodepool_mirror_host }}
+ENV PIP_EXTRA_INDEX_URL {{ nodepool_wheel_mirror }}
 
 RUN echo registry={{ nodepool_npmjs_proxy }} > /etc/npmrc \
     && mkdir -p /usr/etc \

--- a/tests/vars/zuul.yml
+++ b/tests/vars/zuul.yml
@@ -5,3 +5,6 @@ nodepool_mirror_host: "{{ zuul_site_mirror_fqdn }}"
 nodepool_npmjs_proxy: "http://{{ zuul_site_mirror_fqdn }}:8080/registry.npmjs/"
 nodepool_cbs_centos_proxy: "http://{{ zuul_site_mirror_fqdn }}:8080/cbs.centos"
 nodepool_docker_proxy: "http://{{ zuul_site_mirror_fqdn }}:8080/docker"
+
+# NOTE(hrw): wheel cache goes over 80/443 not on 8080
+nodepool_wheel_mirror: "https://{{ zuul_site_mirror_fqdn }}/wheel/{{ ansible_distribution | lower }}-{{ ansible_distribution_version }}-{{ ansible_architecture | lower }}"


### PR DESCRIPTION
Syncs with upstream stable/train (pulls in a patch for Storm on Centos 8 among other things) and adds additional patches to fix Monasca on Centos 8 which are currently in review upstream:

https://review.opendev.org/737927
https://review.opendev.org/737927