### PR TITLE
Added Neutron Mellanox agent image

### DIFF
--- a/doc/source/matrix_aarch64.csv
+++ b/doc/source/matrix_aarch64.csv
@@ -62,6 +62,7 @@ mongodb,N,N,C,C,N,N
 multipathd,C,C,C,C,N,C
 murano,C,C,C,C,N,C
 neutron,C,C,C,C,N,C
+neutron-mlnx-agent,C,C,N,C,N,C
 nova,C,C,C,C,N,C
 nova-spicehtml5proxy,N,N,C,C,N,C
 novajoin,C,C,N,C,N,C

--- a/doc/source/matrix_x86.csv
+++ b/doc/source/matrix_x86.csv
@@ -64,6 +64,7 @@ mongodb,C,C,N,N,C,C,N,N
 multipathd,C,C,C,C,C,C,N,C
 murano,C,C,C,C,C,C,N,C
 neutron,T,T,T,T,T,T,N,T
+neutron-mlnx-agent,C,C,N,N,N,C,N,C
 nova,T,T,T,T,T,T,N,T
 nova-spicehtml5proxy,T,T,N,N,T,T,N,T
 novajoin,C,C,C,C,N,C,N,C

--- a/docker/neutron/neutron-mlnx-agent/Dockerfile.j2
+++ b/docker/neutron/neutron-mlnx-agent/Dockerfile.j2
@@ -1,0 +1,46 @@
+FROM {{ namespace }}/{{ image_prefix }}neutron-base:{{ tag }}
+LABEL maintainer="{{ maintainer }}" name="{{ image_name }}" build-date="{{ build_date }}"
+
+{% block neutron_mlnx_agent_header %}{% endblock %}
+
+{% import "macros.j2" as macros with context %}
+
+{% if base_package_type == 'rpm' %}
+
+    {% set neutron_mlnx_agent_packages = [
+        'libvirt-python',
+        'python-ethtool',
+    ] %}
+
+{% elif base_package_type == 'deb' %}
+
+    {% set neutron_mlnx_agent_packages = [
+        'python-libvirt',
+        'python-ethtool',
+    ] %}
+
+{% endif %}
+
+{% if install_type == 'binary' %}
+
+    {% set neutron_mlnx_agent_packages = neutron_mlnx_agent_packages + [
+        'python-networking-mlnx'
+    ] %}
+
+{{ macros.install_packages(neutron_mlnx_agent_packages | customizable("packages")) }}
+
+{% elif install_type == 'source' %}
+
+    {% set neutron_mlnx_agent_pip_packages = [
+            'networking-mlnx'
+    ] %}
+
+{{ macros.install_packages(neutron_mlnx_agent_packages | customizable("packages")) }}
+RUN {{ macros.install_pip(neutron_mlnx_agent_pip_packages | customizable("pip_packages")) }}
+
+{% endif %}
+
+{% block neutron_mlnx_agent_footer %}{% endblock %}
+{% block footer %}{% endblock %}
+
+USER neutron

--- a/kolla/image/build.py
+++ b/kolla/image/build.py
@@ -241,6 +241,7 @@ UNBUILDABLE_IMAGES = {
         "tacker-base",
         "tripleoclient",
         "trove-base",
+        "neutron-mlnx-agent",
     },
 
     'ubuntu+binary': {
@@ -255,6 +256,7 @@ UNBUILDABLE_IMAGES = {
         "tripleoclient",
         "vitrage-base",
         "zaqar",
+        "neutron-mlnx-agent",
     },
 }
 

--- a/releasenotes/notes/add-neutron-mlnx-agent-b77a4ad9ba3beaae.yaml
+++ b/releasenotes/notes/add-neutron-mlnx-agent-b77a4ad9ba3beaae.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Adds Neutron Mellanox agent image.


### PR DESCRIPTION
Neutron Mellanox agent image is a Neutron base image plus package:
python-networking-mlnx.

Ubuntu and Debian image bases when build type is binary
is not supported because of missing python-networking-mlnx package.

Change-Id: If57c34bd5c3aee3e5b1f1c7b3703fd544ce498da
(cherry picked from commit ac12834c6761551c2b491cfe7ffcd5a69dd80c65)

Conflicts:
	doc/source/matrix_x86.csv
	kolla/image/build.py