### PR TITLE
Upgrade Fluentd Monasca plugin

### DIFF
--- a/docker/fluentd/Dockerfile.j2
+++ b/docker/fluentd/Dockerfile.j2
@@ -81,7 +81,7 @@ RUN chmod 755 /usr/local/bin/kolla_extend_start
 {{ macros.install_fluent_plugins(fluentd_plugins | customizable("plugins")) }}
 
 # Build and install Fluentd output plugin for Monasca Log API
-ARG monasca_output_plugin_tag=0.1.1
+ARG monasca_output_plugin_tag=0.1.2
 ARG monasca_output_plugin_url=https://github.com/monasca/fluentd-monasca/archive/$monasca_output_plugin_tag.tar.gz
 ADD $monasca_output_plugin_url /tmp/fluentd-monasca.tar.gz
 RUN tar -xvf /tmp/fluentd-monasca.tar.gz -C /tmp \

--- a/releasenotes/notes/upgrade-fluentd-monasca-output-plugin-739caf0af953d533.yaml
+++ b/releasenotes/notes/upgrade-fluentd-monasca-output-plugin-739caf0af953d533.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixes an issue which can block the Monasca Fluentd output plugin.
+    `LP#1889065 <https://launchpad.net/bugs/1889065>`__


### PR DESCRIPTION
Switch to YAJI JSON parser as suggested in [1].

[1] https://docs.fluentd.org/quickstart/faq#i-got-encoding-error-inside-plugin-how-to-fix-it

Closes-Bug: #1889065
Change-Id: I2ecd3b029b956e000feaaa9e10a169521ba53d66