### PR TITLE
Install Fluentd Prometheus plugin out of the box (#48)

### DIFF
--- a/docker/fluentd/Dockerfile.j2
+++ b/docker/fluentd/Dockerfile.j2
@@ -67,6 +67,7 @@ RUN chmod 755 /usr/local/bin/kolla_extend_start
         'fluent-plugin-parser',
         'fluent-plugin-rewrite-tag-filter:2.0.0',
         'fluent-plugin-secure-forward',
+        'fluent-plugin-prometheus',
     ] %}
 {% endif %}
 

--- a/releasenotes/notes/add-fluentd-prometheus-plugin-b5c626db667c5675.yaml
+++ b/releasenotes/notes/add-fluentd-prometheus-plugin-b5c626db667c5675.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    The Prometheus plugin is now installed into the Fluentd container by
+    default.


### PR DESCRIPTION
This plugin [1,2] supports a number of use cases which are likely
to be useful out of the box to users enabling either Monasca or
Prometheus:

1. As a system admin I want to monitor the status of Fluentd
   to ensure that it is functioning normally.
2. As a system admin I want to know the time to response for
   calls made to endpoints defined in HAProxy.

[1] https://docs.fluentd.org/deployment/monitoring-prometheus
[2] https://github.com/fluent/fluent-plugin-prometheus

Change-Id: I9790cd6c9d142a4a3ced6d5c9a9af621c3892eb0