### PR TITLE
Victoria: Add libvirt exporter image

### DIFF
--- a/docker/prometheus/prometheus-libvirt-exporter/Dockerfile.j2
+++ b/docker/prometheus/prometheus-libvirt-exporter/Dockerfile.j2
@@ -1,0 +1,45 @@
+FROM {{ namespace }}/{{ image_prefix }}prometheus-base:{{ tag }}
+LABEL maintainer="{{ maintainer }}" name="{{ image_name }}" build-date="{{ build_date }}"
+
+{% import "macros.j2" as macros with context %}
+
+{% block prometheus_libvirt_exporter_header %}{% endblock %}
+
+{% if base_distro in ['centos', 'oraclelinux', 'rhel'] %}
+    {% set prometheus_libvirt_exporter_packages = [
+        'go',
+        'libvirt-devel',
+    ] %}
+{% elif base_distro in ['debian', 'ubuntu'] %}
+    {% set prometheus_libvirt_exporter_packages = [
+        'golang-go',
+        'libvirt-dev',
+    ] %}
+{% endif %}
+
+{{ macros.install_packages(prometheus_libvirt_exporter_packages | customizable("packages")) }}
+
+{% block prometheus_libvirt_exporter_version %}
+ARG prometheus_libvirt_exporter_version=0.1.1
+ARG prometheus_libvirt_exporter_url=https://github.com/kumina/libvirt_exporter.git
+{% endblock %}
+
+{% block prometheus_libvirt_exporter_install %}
+ENV GOPATH=/build
+RUN mkdir /build \
+    && cd /build \
+    && git clone --branch ${prometheus_libvirt_exporter_version} ${prometheus_libvirt_exporter_url} \
+    && cd libvirt_exporter \
+    && go get -d ./... \
+    && go build \
+    && install -m 0755 libvirt_exporter /opt/ \
+    && rm -rf /build
+{% endblock %}
+
+{% block prometheus_libvirt_exporter_footer %}{% endblock %}
+{% block footer %}{% endblock %}
+
+# TODO: Root level access is currently required to read libvirt metrics. In
+# the future we should investigate read only access as a non-root user. See
+# https://libvirt.org/auth.html#ACL_server_polkit.
+USER root

--- a/docker/prometheus/prometheus-libvirt-exporter/Dockerfile.j2
+++ b/docker/prometheus/prometheus-libvirt-exporter/Dockerfile.j2
@@ -1,45 +1,48 @@
-FROM {{ namespace }}/{{ image_prefix }}prometheus-base:{{ tag }}
+FROM {{ namespace }}/{{ infra_image_prefix }}prometheus-base:{{ tag }}
+{% block labels %}
 LABEL maintainer="{{ maintainer }}" name="{{ image_name }}" build-date="{{ build_date }}"
+{% endblock %}
 
 {% import "macros.j2" as macros with context %}
 
 {% block prometheus_libvirt_exporter_header %}{% endblock %}
 
-{% if base_distro in ['centos', 'oraclelinux', 'rhel'] %}
+{% if base_distro in ['centos'] %}
     {% set prometheus_libvirt_exporter_packages = [
         'go',
         'libvirt-devel',
+        'git',
     ] %}
 {% elif base_distro in ['debian', 'ubuntu'] %}
     {% set prometheus_libvirt_exporter_packages = [
         'golang-go',
         'libvirt-dev',
+        'git',
     ] %}
 {% endif %}
 
 {{ macros.install_packages(prometheus_libvirt_exporter_packages | customizable("packages")) }}
 
 {% block prometheus_libvirt_exporter_version %}
-ARG prometheus_libvirt_exporter_version=0.1.1
-ARG prometheus_libvirt_exporter_url=https://github.com/kumina/libvirt_exporter.git
+ARG prometheus_libvirt_exporter_version=2.1.1
+ARG prometheus_libvirt_exporter_url=https://github.com/AlexZzz/libvirt-exporter/archive/refs/tags
 {% endblock %}
 
 {% block prometheus_libvirt_exporter_install %}
 ENV GOPATH=/build
 RUN mkdir /build \
     && cd /build \
-    && git clone --branch ${prometheus_libvirt_exporter_version} ${prometheus_libvirt_exporter_url} \
-    && cd libvirt_exporter \
+    && curl -sSL -o libvirt-exporter.tar.gz ${prometheus_libvirt_exporter_url}/${prometheus_libvirt_exporter_version}.tar.gz  \
+    && tar xvf libvirt-exporter.tar.gz \
+    && cd libvirt-exporter-${prometheus_libvirt_exporter_version} \
     && go get -d ./... \
-    && go build \
-    && install -m 0755 libvirt_exporter /opt/ \
+    && go build -mod vendor \
+    && install -m 0755 libvirt-exporter /opt/ \
     && rm -rf /build
+
 {% endblock %}
 
 {% block prometheus_libvirt_exporter_footer %}{% endblock %}
 {% block footer %}{% endblock %}
 
-# TODO: Root level access is currently required to read libvirt metrics. In
-# the future we should investigate read only access as a non-root user. See
-# https://libvirt.org/auth.html#ACL_server_polkit.
-USER root
+USER prometheus

--- a/docker/prometheus/prometheus-libvirt-exporter/Dockerfile.j2
+++ b/docker/prometheus/prometheus-libvirt-exporter/Dockerfile.j2
@@ -43,5 +43,3 @@ RUN mkdir /build \
 
 {% block prometheus_libvirt_exporter_footer %}{% endblock %}
 {% block footer %}{% endblock %}
-
-USER prometheus

--- a/docker/prometheus/prometheus-libvirt-exporter/Dockerfile.j2
+++ b/docker/prometheus/prometheus-libvirt-exporter/Dockerfile.j2
@@ -35,7 +35,6 @@ RUN mkdir /build \
     && curl -sSL -o libvirt-exporter.tar.gz ${prometheus_libvirt_exporter_url}/${prometheus_libvirt_exporter_version}.tar.gz  \
     && tar xvf libvirt-exporter.tar.gz \
     && cd libvirt-exporter-${prometheus_libvirt_exporter_version} \
-    && go get -d ./... \
     && go build -mod vendor \
     && install -m 0755 libvirt-exporter /opt/ \
     && rm -rf /build

--- a/releasenotes/notes/add-prometheus-libvirt-exporter-8d505dc8b74f8625.yaml
+++ b/releasenotes/notes/add-prometheus-libvirt-exporter-8d505dc8b74f8625.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - Added a container image for Prometheus libvirt exporter, to be used
+    for monitoring deployments which provide VMs with libvirt.


### PR DESCRIPTION
It looks like https://github.com/AlexZzz/libvirt-exporter is a revived fork of the previous exporter project. This PR is a follow up of the work done upstream: https://review.opendev.org/c/openstack/kolla/+/642095