### PR TITLE
Fix Elasticsearch Curator

### DIFF
--- a/docker/elasticsearch/elasticsearch-curator/Dockerfile.j2
+++ b/docker/elasticsearch/elasticsearch-curator/Dockerfile.j2
@@ -26,7 +26,9 @@ LABEL maintainer="{{ maintainer }}" name="{{ image_name }}" build-date="{{ build
 
 {{ macros.configure_user(name='elasticsearch') }}
 
+# NOTE(parallax): pin elasticsearch due to bug: https://bugs.launchpad.net/kolla/+bug/1941073
 {% set elasticsearch_curator_pip_packages = [
+    'elasticsearch==7.13.*',
     'elasticsearch-curator'
 ] %}
 

--- a/releasenotes/notes/fix-elasticsearch-curator-7876896ebbd41ad3.yaml
+++ b/releasenotes/notes/fix-elasticsearch-curator-7876896ebbd41ad3.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fixes an issue with Elasticsearch curator not working due to too new
+    python elasticsearch library.
+    `LP#1941073 <https://bugs.launchpad.net/kolla-ansible/+bug/1941073>`__


### PR DESCRIPTION
Newest elasticsearch python library required by Curator does no longer
work against the last OSS version of Elasticsearch (7.10.2). Pin it
to the last known working version.

Closes-Bug: #1941073
Change-Id: Ic8f0554c95c1903640c98a7831b829c1f88f49ff