### PR TITLE
ceph: Update CentOS packages to Pacific

### DIFF
--- a/doc/source/ceph_versions.csv
+++ b/doc/source/ceph_versions.csv
@@ -1,5 +1,5 @@
 Distro,Ceph,
 ,Source, Release
-CentOS,CentOS Storage SIG,Nautilus
+CentOS,CentOS Storage SIG,Pacific
 Ubuntu,Ubuntu Cloud Archive,Pacific
 Debian,Debian,Nautilus

--- a/docker/base/Dockerfile.j2
+++ b/docker/base/Dockerfile.j2
@@ -190,6 +190,7 @@ RUN rm -f /etc/rpm/macros.image-language-conf \
 
 {% set base_centos_yum_repo_packages = [
     'centos-release-openstack-wallaby',
+    'centos-release-ceph-pacific',
     'centos-release-opstools',
     'epel-release',
 ] %}
@@ -204,6 +205,7 @@ RUN rm -f /etc/rpm/macros.image-language-conf \
 {% set base_centos_yum_repos_to_disable = [
     'centos-advanced-virtualization',
     'centos-ceph-nautilus',
+    'centos-ceph-pacific',
     'centos-nfv-openvswitch',
     'centos-opstools',
     'centos-rabbitmq-38',

--- a/kolla/template/methods.py
+++ b/kolla/template/methods.py
@@ -76,7 +76,7 @@ def handle_repos(context, reponames, mode):
     """NOTE(hrw): we need to handle CentOS, Debian and Ubuntu with one macro.
 
     Repo names have to be simple names mapped to proper ones.  So 'ceph' ==
-    'centos-ceph-nautilus' for CentOS, UCA for Ubuntu (enabled by default) and
+    'centos-ceph-pacific' for CentOS, UCA for Ubuntu (enabled by default) and
     something else for Debian.
     Distro/arch are not required to have all entries - we ignore missing ones.
     """

--- a/kolla/template/repos.yaml
+++ b/kolla/template/repos.yaml
@@ -1,7 +1,6 @@
 ---
-# TODO(mnasiadka): Rework the repo list once Ceph Octopus is released
 centos:
-  ceph: "centos-ceph-nautilus"
+  ceph: "centos-ceph-pacific"
   elasticsearch: "elasticsearch-kibana-logstash-7.x"
   epel: "epel"
   epel-modular: "epel-modular"
@@ -20,7 +19,7 @@ centos:
   td-agent: "treasuredata"
 
 centos-aarch64:
-  ceph: "centos-ceph-nautilus"
+  ceph: "centos-ceph-pacific"
   elasticsearch: "elasticsearch-kibana-logstash-7.x"
   epel: "epel"
   epel-modular: "epel-modular"

--- a/kolla/tests/test_methods.py
+++ b/kolla/tests/test_methods.py
@@ -66,7 +66,7 @@ class MethodsTest(base.TestCase):
         result = methods.handle_repos(template_vars, ['grafana', 'ceph'],
                                       'enable')
         expectCmd = 'RUN dnf config-manager  --enable grafana '
-        expectCmd += '--enable centos-ceph-nautilus || true'
+        expectCmd += '--enable centos-ceph-pacific || true'
         self.assertEqual(expectCmd, result)
 
     def test_enable_repos_debian(self):
@@ -130,7 +130,7 @@ class MethodsTest(base.TestCase):
         result = methods.handle_repos(template_vars, ['grafana', 'ceph'],
                                       'disable')
         expectCmd = 'RUN dnf config-manager  --disable grafana '
-        expectCmd += '--disable centos-ceph-nautilus || true'
+        expectCmd += '--disable centos-ceph-pacific || true'
         self.assertEqual(expectCmd, result)
 
     # NOTE(hrw): there is no disabling of repos for Debian/Ubuntu

--- a/releasenotes/notes/centos-ceph-pacific-40c55be6721cb1ac.yaml
+++ b/releasenotes/notes/centos-ceph-pacific-40c55be6721cb1ac.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Updates Ceph client packages in CentOS images to Pacific.


### PR DESCRIPTION
Updates the CentOS images to use centos-release-ceph-pacific. This is
in line with Ubuntu which gets Pacific from UCA. Debian remains on
Nautilus.

Nautilus has been explicitly disabled in base, as RDO installing it
anyway.

Change-Id: Ie1e77f9c7d83538c051362a8972745f184c72019
(cherry picked from commit c6cba08314816346a9b759bb5da0a2c4ae1a41a6)