### PR TITLE
Ensure set_configs sets execute bit on directories

### DIFF
--- a/docker/base/set_configs.py
+++ b/docker/base/set_configs.py
@@ -20,6 +20,7 @@ import logging
 import os
 import pwd
 import shutil
+import stat
 import sys
 
 
@@ -368,6 +369,15 @@ def handle_permissions(config):
                 if len(perm) == 4 and perm[1] != 'o':
                     perm = ''.join([perm[:1], 'o', perm[1:]])
                 perm = int(perm, base=0)
+
+                # Ensure execute bit on directory if read bit is set
+                if os.path.isdir(path):
+                    if perm & stat.S_IRUSR:
+                        perm |= stat.S_IXUSR
+                    if perm & stat.S_IRGRP:
+                        perm |= stat.S_IXGRP
+                    if perm & stat.S_IROTH:
+                        perm |= stat.S_IXOTH
 
                 try:
                     os.chmod(path, perm)

--- a/releasenotes/notes/set_config-directory-execute-permission-8ab919b7b17025d2.yaml
+++ b/releasenotes/notes/set_config-directory-execute-permission-8ab919b7b17025d2.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixes set_configs.py configuring same permission for directories and files,
+    causing directories lacking execute permission if not set for files.


### PR DESCRIPTION
While handling permissions for directories, set_configs.py configures them
same as for files - i.e. 0640 set in config.json which works fine for file
will cause any potential subdirectories to lack traverse permission.

Check and permission change was added to handle_permissions function
to add +x if +r is present for user, group, others.

Change-Id: Ic6e3ae4ff40c6ce5a5c0646ed309a2938903f6c0