### PR TITLE
Backport of libvirt-exporter

### DIFF
--- a/docker/prometheus/prometheus-libvirt-exporter/Dockerfile.j2
+++ b/docker/prometheus/prometheus-libvirt-exporter/Dockerfile.j2
@@ -1,0 +1,45 @@
+FROM {{ namespace }}/{{ infra_image_prefix }}prometheus-base:{{ tag }}
+{% block labels %}
+LABEL maintainer="{{ maintainer }}" name="{{ image_name }}" build-date="{{ build_date }}"
+{% endblock %}
+
+{% import "macros.j2" as macros with context %}
+
+{% block prometheus_libvirt_exporter_header %}{% endblock %}
+
+{% if base_package_type == 'rpm' %}
+    {% set prometheus_libvirt_exporter_packages = [
+        'git',
+        'go',
+        'libvirt-devel',
+    ] %}
+{% elif base_package_type == 'deb' %}
+    {% set prometheus_libvirt_exporter_packages = [
+        'build-essential',
+        'git',
+        'golang-go',
+        'libvirt-dev',
+        'pkg-config',
+    ] %}
+{% endif %}
+
+{{ macros.install_packages(prometheus_libvirt_exporter_packages | customizable("packages")) }}
+
+{% block prometheus_libvirt_exporter_version %}
+ARG prometheus_libvirt_exporter_version=2.3.0
+ARG prometheus_libvirt_exporter_path=github.com/AlexZzz/libvirt-exporter
+{% endblock %}
+
+{% block prometheus_libvirt_exporter_install %}
+ENV GOPATH=/build
+RUN go mod init libvirt-exporter \
+    && go get -v ${prometheus_libvirt_exporter_path}@${prometheus_libvirt_exporter_version} \
+    && mv /build/bin/libvirt-exporter /opt \
+    && rm -rf /build
+
+{% endblock %}
+
+{% block prometheus_libvirt_exporter_footer %}{% endblock %}
+{% block footer %}{% endblock %}
+
+USER root

--- a/releasenotes/notes/add-prometheus-libvirt-exporter-8d505dc8b74f8625.yaml
+++ b/releasenotes/notes/add-prometheus-libvirt-exporter-8d505dc8b74f8625.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - Added a container image for Prometheus libvirt exporter, to be used
+    for monitoring deployments which provide VMs with libvirt.


### PR DESCRIPTION
This adds a libvirt exporter image for use with Prometheus.

Partially-Implements: blueprint libvirt-exporter
Change-Id: Ice2af99a323496d3821762851b663899d15f569a
(cherry picked from commit afce8598ac098fdb2e11ebac587ef7b13a6d4ec8)
(cherry picked from commit 2b605d3b92a82e5c4054e3c92713db26b7a19d4f)