### PR TITLE
Apply Xena backports from Wallaby

### DIFF
--- a/docker/caso/Dockerfile.j2
+++ b/docker/caso/Dockerfile.j2
@@ -1,0 +1,43 @@
+FROM {{ namespace }}/{{ image_prefix }}openstack-base:{{ tag }}
+LABEL maintainer="{{ maintainer }}" name="{{ image_name }}" build-date="{{ build_date }}"
+
+{% block caso_header %}{% endblock %}
+
+{% import "macros.j2" as macros with context %}
+
+{% if base_distro in ['centos', 'oraclelinux', 'rhel'] %}
+    {% set caso_packages = [
+        'cronie',
+    ] %}
+{% elif base_distro in ['debian', 'ubuntu'] %}
+    {% set caso_packages = [
+        'cron',
+    ] %}
+{% endif %}
+
+{{ macros.install_packages(caso_packages | customizable("packages")) }}
+
+{{ macros.configure_user(name='caso') }}
+
+{% set caso_pip_packages = [
+    'caso'
+] %}
+
+# NOTE(wszumski:) Upgrade pip, otherwise we hit: ModuleNotFoundError: No module
+# named 'setuptools_rust' when install latest cryptography module. Doesn't
+# really make sense to use constraints as caso is not tied to an openstack
+# release.
+RUN mkdir -p /requirements \
+    && curl -sSL -o /requirements/upper-constraints.txt https://releases.openstack.org/constraints/upper/{{ openstack_release }}
+RUN {{ macros.install_pip(["pip"]) }}
+
+RUN {{ macros.install_pip(caso_pip_packages | customizable("pip_packages"),  constraints = false) }} \
+    && mkdir -p /etc/caso \
+    && chown -R caso: /etc/caso
+
+COPY extend_start.sh /usr/local/bin/kolla_extend_start
+
+RUN touch /usr/local/bin/kolla_caso_extend_start \
+    && chmod 755 /usr/local/bin/kolla_extend_start /usr/local/bin/kolla_caso_extend_start
+
+{% block caso_base_footer %}{% endblock %}

--- a/docker/caso/extend_start.sh
+++ b/docker/caso/extend_start.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Create log directory, with appropriate permissions
+CASO_LOG_DIR="/var/log/kolla/caso"
+if [[ ! -d "$CASO_LOG_DIR" ]]; then
+    mkdir -p $CASO_LOG_DIR
+fi
+if [[ $(stat -c %U:%G ${CASO_LOG_DIR}) != "caso:kolla" ]]; then
+    chown caso:kolla ${CASO_LOG_DIR}
+fi
+if [[ $(stat -c %a ${CASO_LOG_DIR}) != "755" ]]; then
+    chmod 755 ${CASO_LOG_DIR}
+fi
+
+. /usr/local/bin/kolla_caso_extend_start

--- a/docker/prometheus/prometheus-jiralert/Dockerfile.j2
+++ b/docker/prometheus/prometheus-jiralert/Dockerfile.j2
@@ -9,7 +9,9 @@ LABEL maintainer="{{ maintainer }}" name="{{ image_name }}" build-date="{{ build
 
 {% if base_package_type == 'rpm' %}
     {% set prometheus_jiralert_packages = [
+        'git',
         'go',
+        'make',
     ] %}
 {% elif base_package_type == 'deb' %}
     {% set prometheus_jiralert_packages = [
@@ -20,17 +22,23 @@ LABEL maintainer="{{ maintainer }}" name="{{ image_name }}" build-date="{{ build
 {{ macros.install_packages(prometheus_jiralert_packages | customizable("packages")) }}
 
 {% block prometheus_jiralert_version %}
-ARG prometheus_jiralert_version=1.0
-ARG prometheus_jiralert_url=https://github.com/prometheus-community/jiralert/releases/download/${prometheus_jiralert_version}/jiralert-${prometheus_jiralert_version}.linux-{{debian_arch}}.tar.gz
+ARG prometheus_jiralert_version=master
+ARG prometheus_jiralert_url=https://github.com/stackhpc/jiralert/archive/refs/heads/${prometheus_jiralert_version}.tar.gz
 {% endblock %}
 
 {% block prometheus_jiralert_install %}
-ENV GOPATH=/tmp
-RUN curl -o /tmp/jiralert.tar.gz ${prometheus_jiralert_url} \
+ENV GOPATH=/build
+RUN mkdir /build \
+    && cd /build \
+    && curl -o jiralert.tar.gz ${prometheus_jiralert_url} \
+    && tar xvf jiralert.tar.gz \
+    && cd jiralert-${prometheus_jiralert_version} \
+    && make build \
     && mkdir /opt/jiralert \
-    && tar --strip 1 -xvf /tmp/jiralert.tar.gz -C /opt/jiralert \
-    && rm -f /tmp/jiralert.tar.gz \
-    && mkdir -p /etc/jiralert
+    && install -m 0755 jiralert /opt/jiralert/ \
+    && install -m 0644 LICENSE /opt/jiralert/ \
+    && install -m 0644 README.md /opt/jiralert/ \
+    && rm -rf /build
 {% endblock %}
 
 {% block prometheus_jiralert_footer %}{% endblock %}

--- a/docker/prometheus/prometheus-jiralert/Dockerfile.j2
+++ b/docker/prometheus/prometheus-jiralert/Dockerfile.j2
@@ -1,0 +1,39 @@
+FROM {{ namespace }}/{{ infra_image_prefix }}prometheus-base:{{ tag }}
+{% block labels %}
+LABEL maintainer="{{ maintainer }}" name="{{ image_name }}" build-date="{{ build_date }}"
+{% endblock %}
+
+{% import "macros.j2" as macros with context %}
+
+{% block prometheus_jiralert_header %}{% endblock %}
+
+{% if base_package_type == 'rpm' %}
+    {% set prometheus_jiralert_packages = [
+        'go',
+    ] %}
+{% elif base_package_type == 'deb' %}
+    {% set prometheus_jiralert_packages = [
+        'golang-go',
+    ] %}
+{% endif %}
+
+{{ macros.install_packages(prometheus_jiralert_packages | customizable("packages")) }}
+
+{% block prometheus_jiralert_version %}
+ARG prometheus_jiralert_version=1.0
+ARG prometheus_jiralert_url=https://github.com/prometheus-community/jiralert/releases/download/${prometheus_jiralert_version}/jiralert-${prometheus_jiralert_version}.linux-{{debian_arch}}.tar.gz
+{% endblock %}
+
+{% block prometheus_jiralert_install %}
+ENV GOPATH=/tmp
+RUN curl -o /tmp/jiralert.tar.gz ${prometheus_jiralert_url} \
+    && mkdir /opt/jiralert \
+    && tar --strip 1 -xvf /tmp/jiralert.tar.gz -C /opt/jiralert \
+    && rm -f /tmp/jiralert.tar.gz \
+    && mkdir -p /etc/jiralert
+{% endblock %}
+
+{% block prometheus_jiralert_footer %}{% endblock %}
+{% block footer %}{% endblock %}
+
+USER prometheus

--- a/docker/prometheus/prometheus-msteams/Dockerfile.j2
+++ b/docker/prometheus/prometheus-msteams/Dockerfile.j2
@@ -1,0 +1,24 @@
+FROM {{ namespace }}/{{ infra_image_prefix }}prometheus-base:{{ tag }}
+{% block labels %}
+LABEL maintainer="{{ maintainer }}" name="{{ image_name }}" build-date="{{ build_date }}"
+{% endblock %}
+
+{% block prometheus_msteams_header %}{% endblock %}
+
+{% block prometheus_msteams_repository_version %}
+ARG prometheus_msteams_version=1.5.0
+ARG prometheus_msteams_sha256sum=74d1bedb12f6ec09fb65ddeb63328f691a9b2a56c92d7682ca152c867fc7c7a0
+{% endblock %}
+
+{% block prometheus_msteams_install %}
+RUN curl -o /tmp/prometheus-msteams https://github.com/prometheus-msteams/prometheus-msteams/releases/download/v${prometheus_msteams_version}/prometheus-msteams-linux-{{debian_arch}} \
+    && echo "${prometheus_msteams_sha256sum} /tmp/prometheus-msteams" | sha256sum -c \
+    && mv /tmp/prometheus-msteams /opt \
+    && chmod 0755 /opt/prometheus-msteams \
+    && mkdir -p /etc/msteams
+{% endblock %}
+
+{% block prometheus_msteams_footer %}{% endblock %}
+{% block footer %}{% endblock %}
+
+USER prometheus

--- a/docker/prometheus/prometheus-openstack-exporter/Dockerfile.j2
+++ b/docker/prometheus/prometheus-openstack-exporter/Dockerfile.j2
@@ -3,17 +3,40 @@ FROM {{ namespace }}/{{ infra_image_prefix }}prometheus-base:{{ tag }}
 LABEL maintainer="{{ maintainer }}" name="{{ image_name }}" build-date="{{ build_date }}"
 {% endblock %}
 
+{% import "macros.j2" as macros with context %}
+
 {% block prometheus_openstack_exporter_header %}{% endblock %}
 
-{% block prometheus_openstack_exporter_repository_version %}
-ENV prometheus_openstack_exporter_version=1.3.0
-{% endblock %}
+{% if base_package_type == 'rpm' %}
+    {% set prometheus_openstack_exporter_packages = [
+        'git',
+        'go',
+        'make',
+    ] %}
+{% elif base_package_type == 'deb' %}
+    {% set prometheus_openstack_exporter_packages = [
+        'build-essential',
+        'git',
+        'golang-go',
+    ] %}
+{% endif %}
+
+{{ macros.install_packages(prometheus_openstack_exporter_packages | customizable("packages")) }}
 
 {% block prometheus_openstack_exporter_install %}
-RUN curl -o /tmp/prometheus_openstack_exporter.tar.gz https://github.com/openstack-exporter/openstack-exporter/releases/download/v${prometheus_openstack_exporter_version}/openstack-exporter-${prometheus_openstack_exporter_version}.linux-{{debian_arch}}.tar.gz \
-    && tar xvf /tmp/prometheus_openstack_exporter.tar.gz -C /opt/ \
-    && rm -f /tmp/prometheus_openstack_exporter.tar.gz \
-    && ln -s /opt/openstack-exporter* /opt/openstack-exporter
+ARG prometheus_openstack_exporter_url=https://github.com/stackhpc/openstack-exporter/archive/refs/heads
+ARG prometheus_openstack_exporter_version=project-parent-id
+ENV GOPATH=/build
+RUN mkdir /build \
+    && cd /build \
+    && curl -o openstack-exporter.tar.gz ${prometheus_openstack_exporter_url}/${prometheus_openstack_exporter_version}.tar.gz  \
+    && tar xvf openstack-exporter.tar.gz \
+    && cd openstack-exporter-${prometheus_openstack_exporter_version} \
+    && make common-build \
+    && mv openstack-exporter-${prometheus_openstack_exporter_version} openstack-exporter \
+    && mkdir /opt/openstack-exporter \
+    && install -m 0755 openstack-exporter /opt/openstack-exporter/ \
+    && rm -rf /build
 {% endblock %}
 
 {% block prometheus_openstack_exporter_footer %}{% endblock %}

--- a/kolla/common/config.py
+++ b/kolla/common/config.py
@@ -664,6 +664,10 @@ USERS = {
         'uid': 42404,
         'gid': 42404,
     },
+    'caso-user': {
+        'uid': 52400,
+        'gid': 52400,
+    },
     'ceilometer-user': {
         'uid': 42405,
         'gid': 42405,

--- a/kolla/image/build.py
+++ b/kolla/image/build.py
@@ -81,6 +81,7 @@ LOG = utils.make_a_logger()
 UNBUILDABLE_IMAGES = {
     'aarch64': {
         "bifrost-base",      # someone need to get upstream working first
+        "prometheus-msteams",  # no aarch64 binary
         "prometheus-mtail",  # no aarch64 binary
         "skydive-base",      # no aarch64 binary
     },

--- a/releasenotes/notes/prometheus-msteams-27e7f23e29f208b4.yaml
+++ b/releasenotes/notes/prometheus-msteams-27e7f23e29f208b4.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Adds ``prometheus-msteams`` image, which can be used to forward Prometheus
+    Alertmanager notifications to Microsoft Teams.


### PR DESCRIPTION
Applied the uncommented commits:
```
8a7b07c96 prometheus-libvirt-exporter: fix build with newer Go
2d4f808c6 Add cASO Docker image
# 5e31a46ca Add Prometheus libvirt exporter image
1f737a1f2 Build openstack-exporter fork from source
a629c55f6 Build jiralert from stackhpc fork
d860b27b3 Add prometheus-msteams image
49dd6d3cd Add Prometheus Jiralert container
# 88bfd6804 ceph: Update CentOS packages to Pacific
# 1a14f9b81 Bump up cAdvisor's version
```