### PR TITLE
jiralert: Fix Ubuntu builds

### DIFF
--- a/docker/prometheus/prometheus-jiralert/Dockerfile.j2
+++ b/docker/prometheus/prometheus-jiralert/Dockerfile.j2
@@ -15,7 +15,8 @@ LABEL maintainer="{{ maintainer }}" name="{{ image_name }}" build-date="{{ build
     ] %}
 {% elif base_package_type == 'deb' %}
     {% set prometheus_jiralert_packages = [
-        'golang-go',
+        'golang-1.16-go',
+        'make',
     ] %}
 {% endif %}
 
@@ -28,7 +29,8 @@ ARG prometheus_jiralert_url=https://github.com/stackhpc/jiralert/archive/refs/he
 
 {% block prometheus_jiralert_install %}
 ENV GOPATH=/build
-RUN mkdir /build \
+RUN PATH={% if base_package_type == 'deb' %}/usr/lib/go-1.16/bin:{% endif %}$PATH \
+    && mkdir /build \
     && cd /build \
     && curl -o jiralert.tar.gz ${prometheus_jiralert_url} \
     && tar xvf jiralert.tar.gz \


### PR DESCRIPTION
* Add make to Ubuntu package deps
* Use golang 1.16, since Focal provides 1.13 but 1.15 is minimum

Change-Id: If9817bf27dc479c644c5e31d928cd2f6312f32ec (cherry picked from commit 25d201a5b425786818c600b5f6052f366062bb06)