### PR TITLE
Revert to using upstream openstack-exporter

### DIFF
--- a/docker/prometheus/prometheus-openstack-exporter/Dockerfile.j2
+++ b/docker/prometheus/prometheus-openstack-exporter/Dockerfile.j2
@@ -3,40 +3,18 @@ FROM {{ namespace }}/{{ infra_image_prefix }}prometheus-base:{{ tag }}
 LABEL maintainer="{{ maintainer }}" name="{{ image_name }}" build-date="{{ build_date }}"
 {% endblock %}
 
-{% import "macros.j2" as macros with context %}
-
 {% block prometheus_openstack_exporter_header %}{% endblock %}
 
-{% if base_package_type == 'rpm' %}
-    {% set prometheus_openstack_exporter_packages = [
-        'git',
-        'go',
-        'make',
-    ] %}
-{% elif base_package_type == 'deb' %}
-    {% set prometheus_openstack_exporter_packages = [
-        'build-essential',
-        'git',
-        'golang-go',
-    ] %}
-{% endif %}
-
-{{ macros.install_packages(prometheus_openstack_exporter_packages | customizable("packages")) }}
+{% block prometheus_openstack_exporter_repository_version %}
+ARG prometheus_openstack_exporter_version=1.6.0
+ARG prometheus_openstack_exporter_url=https://github.com/openstack-exporter/openstack-exporter/releases/download/v${prometheus_openstack_exporter_version}/openstack-exporter_${prometheus_openstack_exporter_version}_linux_{{debian_arch}}.tar.gz
+{% endblock %}
 
 {% block prometheus_openstack_exporter_install %}
-ARG prometheus_openstack_exporter_url=https://github.com/stackhpc/openstack-exporter/archive/refs/heads
-ARG prometheus_openstack_exporter_version=project-parent-id
-ENV GOPATH=/build
-RUN mkdir /build \
-    && cd /build \
-    && curl -o openstack-exporter.tar.gz ${prometheus_openstack_exporter_url}/${prometheus_openstack_exporter_version}.tar.gz  \
-    && tar xvf openstack-exporter.tar.gz \
-    && cd openstack-exporter-${prometheus_openstack_exporter_version} \
-    && make common-build \
-    && mv openstack-exporter-${prometheus_openstack_exporter_version} openstack-exporter \
+RUN curl -o /tmp/prometheus_openstack_exporter.tar.gz ${prometheus_openstack_exporter_url} \
     && mkdir /opt/openstack-exporter \
-    && install -m 0755 openstack-exporter /opt/openstack-exporter/ \
-    && rm -rf /build
+    && tar xvf /tmp/prometheus_openstack_exporter.tar.gz -C /opt/openstack-exporter \
+    && rm -f /tmp/prometheus_openstack_exporter.tar.gz
 {% endblock %}
 
 {% block prometheus_openstack_exporter_footer %}{% endblock %}


### PR DESCRIPTION
The change we had in our `project-parent-id` was merged upstream and released in v1.5.0. We can switch back to building using upstream binaries.

This reverts commit c1850f04b9f72d097de6751ad18822e1fbaf029e.