### PR TITLE
Zed backports

### DIFF
--- a/docker/caso/Dockerfile.j2
+++ b/docker/caso/Dockerfile.j2
@@ -1,0 +1,43 @@
+FROM {{ namespace }}/{{ image_prefix }}openstack-base:{{ tag }}
+LABEL maintainer="{{ maintainer }}" name="{{ image_name }}" build-date="{{ build_date }}"
+
+{% block caso_header %}{% endblock %}
+
+{% import "macros.j2" as macros with context %}
+
+{% if base_distro in ['centos', 'rocky'] %}
+    {% set caso_packages = [
+        'cronie',
+    ] %}
+{% elif base_distro in ['debian', 'ubuntu'] %}
+    {% set caso_packages = [
+        'cron',
+    ] %}
+{% endif %}
+
+{{ macros.install_packages(caso_packages | customizable("packages")) }}
+
+{{ macros.configure_user(name='caso') }}
+
+{% set caso_pip_packages = [
+    'caso'
+] %}
+
+# NOTE(wszumski:) Upgrade pip, otherwise we hit: ModuleNotFoundError: No module
+# named 'setuptools_rust' when install latest cryptography module. Doesn't
+# really make sense to use constraints as caso is not tied to an openstack
+# release.
+RUN mkdir -p /requirements \
+    && curl -sSL -o /requirements/upper-constraints.txt https://releases.openstack.org/constraints/upper/{{ openstack_release }}
+RUN {{ macros.install_pip(["pip"]) }}
+
+RUN {{ macros.install_pip(caso_pip_packages | customizable("pip_packages"),  constraints = false) }} \
+    && mkdir -p /etc/caso \
+    && chown -R caso: /etc/caso
+
+COPY extend_start.sh /usr/local/bin/kolla_extend_start
+
+RUN touch /usr/local/bin/kolla_caso_extend_start \
+    && chmod 755 /usr/local/bin/kolla_extend_start /usr/local/bin/kolla_caso_extend_start
+
+{% block caso_base_footer %}{% endblock %}

--- a/docker/caso/extend_start.sh
+++ b/docker/caso/extend_start.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Create log directory, with appropriate permissions
+CASO_LOG_DIR="/var/log/kolla/caso"
+if [[ ! -d "$CASO_LOG_DIR" ]]; then
+    mkdir -p $CASO_LOG_DIR
+fi
+if [[ $(stat -c %U:%G ${CASO_LOG_DIR}) != "caso:kolla" ]]; then
+    chown caso:kolla ${CASO_LOG_DIR}
+fi
+if [[ $(stat -c %a ${CASO_LOG_DIR}) != "755" ]]; then
+    chmod 755 ${CASO_LOG_DIR}
+fi
+
+. /usr/local/bin/kolla_caso_extend_start

--- a/kolla/common/users.py
+++ b/kolla/common/users.py
@@ -33,6 +33,10 @@ USERS = {
         'uid': 42404,
         'gid': 42404,
     },
+    'caso-user': {
+        'uid': 52400,
+        'gid': 52400,
+    },
     'ceilometer-user': {
         'uid': 42405,
         'gid': 42405,


### PR DESCRIPTION
Commits detailed below

jiralert is no longer in use
```
# git cherry-pick -x 6d0a606cf6  # Add Prometheus Jiralert container
# git cherry-pick -x bf2eaa5426  # Build jiralert from stackhpc fork
# reverted later
# git cherry-pick -x c1850f04b9  # Build openstack-exporter fork from source
git cherry-pick -x 25a32f0579  # Add cASO Docker image
# git cherry-pick -x 3633973c69  # jiralert: Fix Ubuntu builds
# revert of previous commit
# git cherry-pick -x 5e5ce934bd  # Revert "Build openstack-exporter fork from source"

```