### PR TITLE
Pin qemu-kvm in nova-libvirt stream8 images

### DIFF
--- a/docker/nova/nova-libvirt/Dockerfile.j2
+++ b/docker/nova/nova-libvirt/Dockerfile.j2
@@ -25,11 +25,15 @@ LABEL maintainer="{{ maintainer }}" name="{{ image_name }}" build-date="{{ build
         'libvirt-daemon-driver-nodedev',
         'openvswitch',
         'qemu-img',
-        'qemu-kvm',
     ] %}
     {% if not base_distro_tag.startswith('stream9') and not base_distro == 'rocky' %}
         {% set nova_libvirt_packages = nova_libvirt_packages + [
+            'qemu-kvm-6.2.0-35.module_el8+466+00f6f2b0.x86_64',
             'trousers'
+        ] %}
+    {% else %}
+        {% set nova_libvirt_packages = nova_libvirt_packages + [
+            'qemu-kvm',
         ] %}
     {% endif %}
     {% if base_arch == 'x86_64' %}


### PR DESCRIPTION
Live migration is broken from the previous version included in our nova-libvirt image (qemu-kvm-6.2.0-20.module_el8.7.0+1218+f626c2ff) to qemu-kvm-6.2.0-37.module_el8+571+1f6ddcef and later with signature:

    Missing section footer for 0000:00:01.3/piix4_pm

Pin to the last compatible version:
qemu-kvm-6.2.0-35.module_el8+466+00f6f2b0

Change-Id: I96df8aac9cee1a90fcc864c0bc362040bdc817b5