### PR TITLE
Update Prometheus services to latest releases

### DIFF
--- a/docker/prometheus/prometheus-alertmanager/Dockerfile.j2
+++ b/docker/prometheus/prometheus-alertmanager/Dockerfile.j2
@@ -6,7 +6,7 @@ LABEL maintainer="{{ maintainer }}" name="{{ image_name }}" build-date="{{ build
 {% block prometheus_alertmanager_header %}{% endblock %}
 
 {% block prometheus_alertmanager_repository_version %}
-ARG prometheus_alertmanager_version=0.24.0
+ARG prometheus_alertmanager_version=0.26.0
 ARG prometheus_alertmanager_archive=alertmanager-${prometheus_alertmanager_version}.linux-{{debian_arch}}.tar.gz
 ARG prometheus_alertmanager_sha256sums_url=https://github.com/prometheus/alertmanager/releases/download/v${prometheus_alertmanager_version}/sha256sums.txt
 ARG prometheus_alertmanager_download_url=https://github.com/prometheus/alertmanager/releases/download/v${prometheus_alertmanager_version}/${prometheus_alertmanager_archive}

--- a/docker/prometheus/prometheus-blackbox-exporter/Dockerfile.j2
+++ b/docker/prometheus/prometheus-blackbox-exporter/Dockerfile.j2
@@ -8,7 +8,7 @@ LABEL maintainer="{{ maintainer }}" name="{{ image_name }}" build-date="{{ build
 {% import "macros.j2" as macros with context %}
 
 {% block prometheus_blackbox_exporter_repository_version %}
-ARG blackbox_exporter_version=0.22.0
+ARG blackbox_exporter_version=0.24.0
 ARG blackbox_exporter_url=https://github.com/prometheus/blackbox_exporter/releases/download/v${blackbox_exporter_version}/blackbox_exporter-${blackbox_exporter_version}.linux-{{debian_arch}}.tar.gz
 {% endblock %}
 

--- a/docker/prometheus/prometheus-cadvisor/Dockerfile.j2
+++ b/docker/prometheus/prometheus-cadvisor/Dockerfile.j2
@@ -8,11 +8,11 @@ LABEL maintainer="{{ maintainer }}" name="{{ image_name }}" build-date="{{ build
 {% import "macros.j2" as macros with context %}
 
 {% block prometheus_cadvisor_repository_version %}
-ARG prometheus_cadvisor_version=0.45.0
+ARG prometheus_cadvisor_version=0.47.2
 {% if debian_arch == 'arm64' %}
-ARG prometheus_cadvisor_sha256sum=bd6dad982c5950d6071ec2e1f9d474102ef3a00451395c58da9398297d35b174
+ARG prometheus_cadvisor_sha256sum=a15ebac9c60cccbb035e4af83cd45211edac19f3204ed0614b3336fddf91444b
 {% else %}
-ARG prometheus_cadvisor_sha256sum=9a2a0b69f58d932855c0af23b847cb9de8f8c32264f66f9fb5dcc8f359f34ccd
+ARG prometheus_cadvisor_sha256sum=30602f675e9bcd39b0d4cd4bd9e83c0849dd4bb3a60a0544b9f2a6451a3facfe
 {% endif %}
 ARG prometheus_cadvisor_url=https://github.com/google/cadvisor/releases/download/v${prometheus_cadvisor_version}/cadvisor-v${prometheus_cadvisor_version}-linux-{{debian_arch}}
 {% endblock %}

--- a/docker/prometheus/prometheus-elasticsearch-exporter/Dockerfile.j2
+++ b/docker/prometheus/prometheus-elasticsearch-exporter/Dockerfile.j2
@@ -6,7 +6,7 @@ LABEL maintainer="{{ maintainer }}" name="{{ image_name }}" build-date="{{ build
 {% block prometheus_elasticsearch_exporter_header %}{% endblock %}
 
 {% block prometheus_elasticsearch_exporter_repository_version %}
-ARG elasticsearch_exporter_version=1.5.0
+ARG elasticsearch_exporter_version=1.6.0
 ARG elasticsearch_exporter_url=https://github.com/prometheus-community/elasticsearch_exporter/releases/download/v${elasticsearch_exporter_version}/elasticsearch_exporter-${elasticsearch_exporter_version}.linux-{{debian_arch}}.tar.gz
 {% endblock %}
 

--- a/docker/prometheus/prometheus-haproxy-exporter/Dockerfile.j2
+++ b/docker/prometheus/prometheus-haproxy-exporter/Dockerfile.j2
@@ -6,7 +6,7 @@ LABEL maintainer="{{ maintainer }}" name="{{ image_name }}" build-date="{{ build
 {% block haproxy_exporter_header %}{% endblock %}
 
 {% block haproxy_exporter_repository_version %}
-ARG haproxy_exporter_version=0.13.0
+ARG haproxy_exporter_version=0.15.0
 ARG haproxy_exporter_url=https://github.com/prometheus/haproxy_exporter/releases/download/v${haproxy_exporter_version}/haproxy_exporter-${haproxy_exporter_version}.linux-{{debian_arch}}.tar.gz
 {% endblock %}
 

--- a/docker/prometheus/prometheus-memcached-exporter/Dockerfile.j2
+++ b/docker/prometheus/prometheus-memcached-exporter/Dockerfile.j2
@@ -6,7 +6,7 @@ LABEL maintainer="{{ maintainer }}" name="{{ image_name }}" build-date="{{ build
 {% block prometheus_memcached_exporter_header %}{% endblock %}
 
 {% block prometheus_memcached_exporter_repository_version %}
-ARG memcached_exporter_version=0.10.0
+ARG memcached_exporter_version=0.13.0
 ARG memcached_exporter_url=https://github.com/prometheus/memcached_exporter/releases/download/v${memcached_exporter_version}/memcached_exporter-${memcached_exporter_version}.linux-{{debian_arch}}.tar.gz
 {% endblock %}
 

--- a/docker/prometheus/prometheus-msteams/Dockerfile.j2
+++ b/docker/prometheus/prometheus-msteams/Dockerfile.j2
@@ -6,8 +6,8 @@ LABEL maintainer="{{ maintainer }}" name="{{ image_name }}" build-date="{{ build
 {% block prometheus_msteams_header %}{% endblock %}
 
 {% block prometheus_msteams_repository_version %}
-ARG prometheus_msteams_version=1.5.1
-ARG prometheus_msteams_sha256sum=9a589b4417fc116c153c40d1220dca1f46e6bb8e24b4db0d52ee0c0151de2222
+ARG prometheus_msteams_version=1.5.2
+ARG prometheus_msteams_sha256sum=0f4df9ee31e655d1ec876ea2c53ab5ae5b07143ef21b9190e61b4d52839e135c
 ARG prometheus_msteams_url=https://github.com/prometheus-msteams/prometheus-msteams/releases/download/v${prometheus_msteams_version}/prometheus-msteams-linux-{{debian_arch}}
 {% endblock %}
 

--- a/docker/prometheus/prometheus-mtail/Dockerfile.j2
+++ b/docker/prometheus/prometheus-mtail/Dockerfile.j2
@@ -7,9 +7,9 @@ LABEL maintainer="{{ maintainer }}" name="{{ image_name }}" build-date="{{ build
 
 {% block prometheus_mtail_version %}
 
-ARG prometheus_mtail_version=3.0.0-rc50
+ARG prometheus_mtail_version=3.0.0-rc52
 {% if debian_arch == 'amd64' %}
-ARG prometheus_mtail_url=https://github.com/google/mtail/releases/download/v${prometheus_mtail_version}/mtail_${prometheus_mtail_version}_linux_x86_64.tar.gz
+ARG prometheus_mtail_url=https://github.com/google/mtail/releases/download/v${prometheus_mtail_version}/mtail_${prometheus_mtail_version}_linux_amd64.tar.gz
 {% else %}
 ARG prometheus_mtail_url=https://github.com/google/mtail/releases/download/v${prometheus_mtail_version}/mtail_${prometheus_mtail_version}_linux_{{debian_arch}}.tar.gz
 {% endif %}

--- a/docker/prometheus/prometheus-mysqld-exporter/Dockerfile.j2
+++ b/docker/prometheus/prometheus-mysqld-exporter/Dockerfile.j2
@@ -6,7 +6,7 @@ LABEL maintainer="{{ maintainer }}" name="{{ image_name }}" build-date="{{ build
 {% block mysqld_exporter_header %}{% endblock %}
 
 {% block mysqld_exporter_repository_version %}
-ARG mysqld_exporter_version=0.14.0
+ARG mysqld_exporter_version=0.15.0
 ARG mysqld_exporter_url=https://github.com/prometheus/mysqld_exporter/releases/download/v${mysqld_exporter_version}/mysqld_exporter-${mysqld_exporter_version}.linux-{{debian_arch}}.tar.gz
 {% endblock %}
 

--- a/docker/prometheus/prometheus-node-exporter/Dockerfile.j2
+++ b/docker/prometheus/prometheus-node-exporter/Dockerfile.j2
@@ -6,11 +6,11 @@ LABEL maintainer="{{ maintainer }}" name="{{ image_name }}" build-date="{{ build
 {% block node_exporter_header %}{% endblock %}
 
 {% block node_exporter_repository_version %}
-ARG node_exporter_version=1.4.0
+ARG node_exporter_version=1.7.0
 {% if debian_arch == 'arm64' %}
-ARG node_exporter_sha256sum=0b20aa75385a42857a67ee5f6c7f67b229039a22a49c5c61c33f071356415b59
+ARG node_exporter_sha256sum=e386c7b53bc130eaf5e74da28efc6b444857b77df8070537be52678aefd34d96
 {% else %}
-ARG node_exporter_sha256sum=e77ff1b0a824a4e13f82a35d98595fe526849c09e3480d0789a56b72242d2abc
+ARG node_exporter_sha256sum=a550cd5c05f760b7934a2d0afad66d2e92e681482f5f57a917465b1fba3b02a6
 {% endif %}
 ARG node_exporter_url=https://github.com/prometheus/node_exporter/releases/download/v{$node_exporter_version}/node_exporter-${node_exporter_version}.linux-{{debian_arch}}.tar.gz
 {% endblock %}

--- a/docker/prometheus/prometheus-ovn-exporter/Dockerfile.j2
+++ b/docker/prometheus/prometheus-ovn-exporter/Dockerfile.j2
@@ -13,7 +13,7 @@ ARG ovn_arch=amd64
 ARG ovn_arch=arm64
 {% endif %}
 
-ARG prometheus_ovn_version=1.0.6
+ARG prometheus_ovn_version=1.0.7
 ARG prometheus_ovn_cksum_url=https://github.com/greenpau/ovn_exporter/releases/download/v${prometheus_ovn_version}/checksums.txt
 ARG ovn_exporter_tgz=ovn-exporter_${prometheus_ovn_version}_linux_${ovn_arch}.tar.gz
 ARG prometheus_ovn_url=https://github.com/greenpau/ovn_exporter/releases/download/v${prometheus_ovn_version}/${ovn_exporter_tgz}

--- a/docker/prometheus/prometheus-v2-server/Dockerfile.j2
+++ b/docker/prometheus/prometheus-v2-server/Dockerfile.j2
@@ -6,7 +6,7 @@ LABEL maintainer="{{ maintainer }}" name="{{ image_name }}" build-date="{{ build
 {% block prometheus_v2_server_header %}{% endblock %}
 
 {% block prometheus_v2_server_repository_version %}
-ARG prometheus_version=2.38.0
+ARG prometheus_version=2.48.0
 ARG prometheus_url=https://github.com/prometheus/prometheus/releases/download/v${prometheus_version}/prometheus-${prometheus_version}.linux-{{debian_arch}}.tar.gz
 {% endblock %}
 

--- a/releasenotes/notes/update-prometheus-services-e53dfdb490ac700e.yaml
+++ b/releasenotes/notes/update-prometheus-services-e53dfdb490ac700e.yaml
@@ -1,0 +1,16 @@
+---
+upgrade:
+  - |
+    Update Prometheus services to latest releases:
+     * blackbox_exporter 0.22.0 -> 0.24.0
+     * elasticsearch_exporter 1.5.0 -> 1.6.0
+     * haproxy_exporter 0.13.0 -> 0.15.0
+     * memcached_exporter 0.10.0 -> 0.13.0
+     * mysqld_exporter 0.14.0 -> 0.15.0
+     * node_exporter 1.4.0 -> 1.7.0
+     * ovn_exporter 1.0.6 -> 1.0.7
+     * prometheus 2.38.0 -> 2.48.0
+     * prometheus_alertmanager 0.24.0 -> 0.26.0
+     * prometheus_cadvisor 0.45.0 -> 0.47.2
+     * prometheus_mtail v3.0.0-rc50 -> v3.0.0-rc52
+     * prometheus_msteams 1.5.1 -> 1.5.2


### PR DESCRIPTION
blackbox_exporter 0.22.0 -> 0.24.0
elasticsearch_exporter 1.5.0 -> 1.6.0
haproxy_exporter 0.13.0 -> 0.15.0
memcached_exporter 0.10.0 -> 0.13.0
mysqld_exporter 0.14.0 -> 0.15.0
node_exporter 1.4.0 -> 1.7.0
ovn_exporter 1.0.6 -> 1.0.7
prometheus 2.38.0 -> 2.48.0
prometheus_alertmanager 0.24.0 -> 0.26.0
prometheus_cadvisor 0.45.0 -> 0.47.2
prometheus_mtail v3.0.0-rc50 -> v3.0.0-rc52
prometheus_msteams 1.5.1 -> 1.5.2

Change-Id: If3f6ff059bedba5c92d97442d77e44aeecef71c4 (cherry picked from commit 773c6963e2405af3d535c41d7794361a079b71c4)