### PR TITLE
Add ovn-sb-db-relay image with newer ovn-ctl

### DIFF
--- a/docker/ovn/ovn-sb-db-relay/Dockerfile.j2
+++ b/docker/ovn/ovn-sb-db-relay/Dockerfile.j2
@@ -1,0 +1,15 @@
+FROM {{ namespace }}/{{ image_prefix }}ovn-sb-db-server:{{ tag }}
+{% block labels %}
+LABEL maintainer="{{ maintainer }}" name="{{ image_name }}" build-date="{{ build_date }}"
+{% endblock %}
+
+{% block ovn_sb_db_server_header %}{% endblock %}
+
+{% block ovn_sb_db_relay_ovn_ctl %}
+{# TODO(mnasiadka): Switch to 25.03 branch when available, ideally rpm/deb packages will be
+                    available. #}
+RUN curl -o /usr/share/ovn/scripts/ovn-ctl https://raw.githubusercontent.com/ovn-org/ovn/refs/heads/main/utilities/ovn-ctl
+{% endblock %}
+
+{% block ovn_sb_db_relay_footer %}{% endblock %}
+{% block footer %}{% endblock %}


### PR DESCRIPTION
We need newer ovn-ctl with [1] - for now download that from ovn-org/ovn@master - once 25.03 is branched we should get that the normal way.

[1]: https://github.com/ovn-org/ovn/commit/2ecba75432cf90ffb5d6a3a53b8aed521ecf0f44

Change-Id: I429f00ed4bdcd24409d14453ab53c5fa11fdb00b