### PR TITLE
Caracal: Update monitoring stack components

### DIFF
--- a/kolla/common/sources.py
+++ b/kolla/common/sources.py
@@ -278,44 +278,44 @@ SOURCES = {
         'location': ('$tarballs_base/openstack/placement/'
                      'placement-${openstack_branch}.tar.gz')},
     'prometheus-alertmanager': {
-        'version': '0.27.0',
+        'version': '0.28.0',
         'type': 'url',
         'sha256': {
-            'amd64': '23c3f5a3c73de91dbaec419f3c492bef636deb02680808e5d842e6553aa16074',  # noqa: E501
-            'arm64': 'a754304b682cec61f4bd5cfc029b451a30134554b3a2f21a9c487e12814ff8f3'},  # noqa: E501
+            'amd64': '6b5a38d32cddef23aad4435a58c1ea39dc0a07b4b155029c601d200720da9ca4',  # noqa: E501
+            'arm64': '70d7c85a364d5d5d20e36dfff6886fbc5e105822642d5603cc2f38340dd2f7ee'},  # noqa: E501
         'location': ('https://github.com/'
                      'prometheus/alertmanager/'
                      'releases/download/v${version}/'
                      'alertmanager'
                      '-${version}.linux-${debian_arch}.tar.gz')},
     'prometheus-blackbox-exporter': {
-        'version': '0.24.0',
+        'version': '0.25.0',
         'type': 'url',
         'sha256': {
-            'amd64': '81b36cece040491ac0d9995db2a0964c40e24838a03a151c3333a7dc3eef94ff',  # noqa: E501
-            'arm64': 'acbbedf03de862fa833bc4dd810e63f105cb44e47abf493192fce3451852dc58'},  # noqa: E501
+            'amd64': 'c651ced6405c5e0cd292a400f47ae9b34f431f16c7bb098afbcd38f710144640',  # noqa: E501
+            'arm64': '46ec5a54a41dc1ea8a8cecee637e117de4807d3b0976482a16596e82e79ac484'},  # noqa: E501
         'location': ('https://github.com/'
                      'prometheus/blackbox_exporter/'
                      'releases/download/v${version}/'
                      'blackbox_exporter'
                      '-${version}.linux-${debian_arch}.tar.gz')},
     'prometheus-cadvisor': {
-        'version': '0.49.1',
+        'version': '0.49.2',
         'type': 'url',
         'sha256': {
-            'amd64': '1d5cc701a3fcdf1e8ed1c86da5304b896a6997d9e6673139e78a6f87812495b0',  # noqa: E501
-            'arm64': 'c535f46d789599f25c7c680af193d4402da27a98d9828eb2ec916af6256e0c0c'},  # noqa: E501
+            'amd64': 'e8273ebfd18bac96834de3eb74a86bda4c2c6d6e9b4c924bdbf1f93e4e0bc24f',  # noqa: E501
+            'arm64': '5b852edb911cfe3df7448b03ccbdc6538b6ff00299527864234127cc54f8080f'},  # noqa: E501
         'location': ('https://github.com/'
                      'google/cadvisor/'
                      'releases/download/v${version}/'
                      'cadvisor'
                      '-v${version}-linux-${debian_arch}')},
     'prometheus-elasticsearch-exporter': {
-        'version': '1.7.0',
+        'version': '1.8.0',
         'type': 'url',
         'sha256': {
-            'amd64': '45aff83bcea639dc977e34eaa6ad7b1453be96be469f570b39c2d4fc69bf5ffc',  # noqa: E501
-            'arm64': '0cf7828f3da1aba73ebef6192ee885345ecd628df782b23aee9c81fa311b92ad'},  # noqa: E501
+            'amd64': 'a03a19d015c45ccc9e35f3a99c6a202b347a521a494cff0e404f9038e426135a',  # noqa: E501
+            'arm64': '493ceef304a54e60dfcd0c477d4f0ddad02cfbbb975532f1cb3a169e662f4eea'},  # noqa: E501
         'location': ('https://github.com/'
                      'prometheus-community/elasticsearch_exporter/'
                      'releases/download/v${version}/'
@@ -333,11 +333,11 @@ SOURCES = {
                      'prometheus-libvirt-exporter'
                      '-${version}.linux-${debian_arch}.tar.gz')},
     'prometheus-memcached-exporter': {
-        'version': '0.14.2',
+        'version': '0.15.0',
         'type': 'url',
         'sha256': {
-            'amd64': '11219035ad3cf63b174d04f52df7188fad8cd7a271631fba97a0e61b4d5e597f',  # noqa: E501
-            'arm64': '1790f7c87aa950b5c3d87c7db998be797087699290f5c1dccb16b1b4611056bc'},  # noqa: E501
+            'amd64': 'd628bd8119b8e69696f61bdf6736490962d5abd52d35207b58a547447aa4e74f',  # noqa: E501
+            'arm64': '1ec401184ed207c40e8ab8323f46d116f6ff7654ea4040fe0d786af237c5df8d'},  # noqa: E501
         'location': ('https://github.com/'
                      'prometheus/memcached_exporter/'
                      'releases/download/v${version}/'
@@ -354,33 +354,33 @@ SOURCES = {
                      'prometheus-msteams'
                      '-linux-${debian_arch}')},
     'prometheus-mtail': {
-        'version': '3.0.0-rc54',
+        'version': '3.0.8',
         'type': 'url',
         'sha256': {
-            'amd64': '6f6cb9c5f2eec6494ecbec9e3f6f0ab9444ef57844143749d7a5b2d2ab1819d6',  # noqa: E501
-            'arm64': '6b7049bc44cfe5e90ffeb3ff6cbd2176a3dc7cd9df32ff9e10e1d303d38389e1'},  # noqa: E501
+            'amd64': '123c2ee5f48c3eff12ebccee38befd2233d715da736000ccde49e3d5607724e4',  # noqa: E501
+            'arm64': 'aa04811c0929b6754408676de520e050c45dddeb3401881888a092c9aea89cae'},  # noqa: E501
         'location': ('https://github.com/'
                      'google/mtail/'
                      'releases/download/v${version}/'
                      'mtail'
                      '_${version}_linux_${debian_arch}.tar.gz')},
     'prometheus-mysqld-exporter': {
-        'version': '0.15.1',
+        'version': '0.16.0',
         'type': 'url',
         'sha256': {
-            'amd64': '85ea5bc68e1b9f466c1df10ff016652dd210371d42245e012b876265e89ae29d',  # noqa: E501
-            'arm64': '8f55c2dcc41aab5998c1e22a2e78e5a940c6894b462736b129fd7bf9b48f8f60'},  # noqa: E501
+            'amd64': '32fe0b59ef3f52624a1958aaf6b8855f27c2b492a7026d62a975bbd251be209d',  # noqa: E501
+            'arm64': '9ffc6e107bd122e68a95fa5c194bc3fc257104fef6ed720a26a240cd608c777b'},  # noqa: E501
         'location': ('https://github.com/'
                      'prometheus/mysqld_exporter/'
                      'releases/download/v${version}/'
                      'mysqld_exporter'
                      '-${version}.linux-${debian_arch}.tar.gz')},
     'prometheus-node-exporter': {
-        'version': '1.7.0',
+        'version': '1.8.2',
         'type': 'url',
         'sha256': {
-            'amd64': 'a550cd5c05f760b7934a2d0afad66d2e92e681482f5f57a917465b1fba3b02a6',  # noqa: E501
-            'arm64': 'e386c7b53bc130eaf5e74da28efc6b444857b77df8070537be52678aefd34d96'},  # noqa: E501
+            'amd64': '6809dd0b3ec45fd6e992c19071d6b5253aed3ead7bf0686885a51d85c6643c66',  # noqa: E501
+            'arm64': '627382b9723c642411c33f48861134ebe893e70a63bcc8b3fc0619cd0bfac4be'},  # noqa: E501
         'location': ('https://github.com/'
                      'prometheus/node_exporter/'
                      'releases/download/v${version}/'
@@ -409,11 +409,11 @@ SOURCES = {
                      'ovn-exporter'
                      '_${version}_linux_${debian_arch}.tar.gz')},
     'prometheus-v2-server': {
-        'version': '2.50.1',
+        'version': '2.55.1',
         'type': 'url',
         'sha256': {
-            'amd64': '936f3777f8c3a4a90d3c58a6f410350d5932c79367b99771d002bd36e48bd05b',  # noqa: E501
-            'arm64': '9f1a65cf08cef3dcd5f0d38d8673ecfaf1054aa9e1e5c18c94efd8546c1fdd96'},  # noqa: E501
+            'amd64': '19700bdd42ec31ee162e4079ebda4cd0a44432df4daa637141bdbea4b1cd8927',  # noqa: E501
+            'arm64': 'af43368bc6379c3c8bd5ac0b82208060bba22267bf01ad3ab5df56ad5725bf88'},  # noqa: E501
         'location': ('https://github.com/'
                      'prometheus/prometheus/'
                      'releases/download/v${version}/'

--- a/releasenotes/notes/update-prometheus-services-dd195876e162251c.yaml
+++ b/releasenotes/notes/update-prometheus-services-dd195876e162251c.yaml
@@ -1,0 +1,17 @@
+---
+upgrade:
+  - |
+    Update Prometheus services to latest releases:
+
+    * prometheus-alertmanager: 0.27.0 -> 0.28.0
+    * prometheus-blackbox-exporter: 0.24.0 -> 0.25.0
+    * prometheus-cadvisor: 0.49.1 -> 0.49.2
+    * prometheus-elasticsearch-exporter: 1.7.0 -> 1.8.0
+    * prometheus-memcached-exporter: 0.14.2 -> 0.15.0
+    * prometheus-mtail: 3.0.0-rc54 -> 3.0.8
+    * prometheus-mysqld-exporter: 0.15.1 -> 0.16.0
+    * prometheus-node-exporter: 1.7.0 -> 1.8.2
+    * prometheus 2.50.1 -> 2.55.1
+
+    This upgrade migrates to a new TSDB format which is
+    compatible with Prometheus v3.


### PR DESCRIPTION
prometheus-alertmanager: 0.27.0 -> 0.28.0
prometheus-blackbox-exporter: 0.24.0 -> 0.25.0
prometheus-cadvisor: 0.49.1 -> 0.49.2
prometheus-elasticsearch-exporter: 1.7.0 -> 1.8.0
prometheus-memcached-exporter: 0.14.2 -> 0.15.0
prometheus-mtail: 3.0.0-rc54 -> 3.0.8
prometheus-mysqld-exporter: 0.15.1 -> 0.16.0
prometheus-node-exporter: 1.7.0 -> 1.8.2
prometheus 2.50.1 -> 2.55.1

Co-authored-by: Piotr Parczewski <piotr@stackhpc.com>

Change-Id: I9359df23a41a600dd46dbc1812a54be57fd33f71