### PR TITLE
Update prometheus alertmanager to newest available version

### DIFF
--- a/docker/base/Dockerfile.j2
+++ b/docker/base/Dockerfile.j2
@@ -241,15 +241,15 @@ RUN cat /tmp/kolla_bashrc >> /etc/bash.bashrc \
 RUN rm -f /etc/apt/sources.list.d/debian.sources
 COPY sources.list.{{ base_distro }} /etc/apt/sources.list
 {% elif ( base_distro == 'ubuntu' and base_arch == 'x86_64' ) %}
-{% if base_distro_tag.startswith('22.04') %}
+{% if base_distro_tag.startswith('22.04') or base_distro_tag.startswith('jammy') %}
 COPY sources.list.{{ base_distro }}.jammy /etc/apt/sources.list
-{% elif base_distro_tag.startswith('24.04') %}
+{% elif base_distro_tag.startswith('24.04') or base_distro_tag.startswith('noble') %}
 COPY sources.list.{{ base_distro }}.noble /etc/apt/sources.list
 {% endif %}
 {% else %}
-{% if base_distro_tag.startswith('22.04') %}
+{% if base_distro_tag.startswith('22.04')  or base_distro_tag.startswith('jammy')%}
 COPY sources.list.{{ base_distro }}.jammy.{{ base_arch }} /etc/apt/sources.list
-{% elif base_distro_tag.startswith('24.04') %}
+{% elif base_distro_tag.startswith('24.04') or base_distro_tag.startswith('noble')%}
 COPY sources.list.{{ base_distro }}.noble.{{ base_arch }} /etc/apt/sources.list
 {% endif %}
 {% endif %}

--- a/docker/bifrost/bifrost-base/Dockerfile.j2
+++ b/docker/bifrost/bifrost-base/Dockerfile.j2
@@ -37,7 +37,7 @@ ENV ANSIBLE_GATHER_TIMEOUT=30
 {% block bifrost_ansible_install %}
 {%- if base_package_type == 'deb' %}
 RUN apt-get --error-on=any update && \
-    {%- if base_distro_tag.startswith('24.04') %}
+    {%- if base_distro_tag.startswith('24.04') or base_distro_tag.startswith('noble') %}
     bash -c 'export VENV=/var/lib/kolla/venv && \
     {# NOTE(darmach): Bumped to ansible-core 2.16 to match Python 3.12 #}
     $VENV/bin/pip install "ansible>=9,<10" && \

--- a/docker/cinder/cinder-base/Dockerfile.j2
+++ b/docker/cinder/cinder-base/Dockerfile.j2
@@ -32,7 +32,7 @@ LABEL maintainer="{{ maintainer }}" name="{{ image_name }}" build-date="{{ build
     ] %}
 {% endif %}
 
-{% if base_distro_tag.startswith('24.04') %}
+{% if base_distro_tag.startswith('24.04') or base_distro_tag.startswith('noble') %}
 RUN {{ macros.upper_constraints_version_change("taskflow", "5.6.0", "5.8.0") }}
 {% endif %}
 

--- a/kolla/common/sources.py
+++ b/kolla/common/sources.py
@@ -278,11 +278,11 @@ SOURCES = {
         'location': ('$tarballs_base/openstack/placement/'
                      'placement-${openstack_branch}.tar.gz')},
     'prometheus-alertmanager': {
-        'version': '0.28.0',
+        'version': '0.28.1',
         'type': 'url',
         'sha256': {
-            'amd64': '6b5a38d32cddef23aad4435a58c1ea39dc0a07b4b155029c601d200720da9ca4',  # noqa: E501
-            'arm64': '70d7c85a364d5d5d20e36dfff6886fbc5e105822642d5603cc2f38340dd2f7ee'},  # noqa: E501
+            'amd64': '5ac7ab5e4b8ee5ce4d8fb0988f9cb275efcc3f181b4b408179fafee121693311',  # noqa: E501
+            'arm64': 'd8832540e5b9f613d2fd759e31d603173b9c61cc7bb5e3bc7ae2f12038b1ce4f'},  # noqa: E501
         'location': ('https://github.com/'
                      'prometheus/alertmanager/'
                      'releases/download/v${version}/'

--- a/kolla/image/kolla_worker.py
+++ b/kolla/image/kolla_worker.py
@@ -122,7 +122,7 @@ class KollaWorker(object):
             self.distro_package_manager = 'apt'
             self.base_package_type = 'deb'
         elif self.base in ['ubuntu']:
-            if self.base_tag.startswith('24.04'):
+            if self.base_tag.startswith(('24.04', 'noble')):
                 self.conf.distro_python_version = "3.12"
             else:
                 self.conf.distro_python_version = "3.10"

--- a/kolla/template/methods.py
+++ b/kolla/template/methods.py
@@ -96,7 +96,14 @@ def handle_repos(context, reponames, mode):
 
     repofile = context.get('repos_yaml') or (
         os.path.dirname(os.path.realpath(__file__)) +
-        ('/repos-noble.yaml' if base_distro_tag == '24.04' else '/repos.yaml')
+        (
+            '/repos-noble.yaml'
+            if (
+                base_distro_tag and
+                base_distro_tag.startswith(('24.04', 'noble'))
+            )
+            else '/repos.yaml'
+        )
     )
 
     with open(repofile, 'r') as repos_file:

--- a/releasenotes/notes/update-alertmanager-a7291d4d43423657.yaml
+++ b/releasenotes/notes/update-alertmanager-a7291d4d43423657.yaml
@@ -1,0 +1,13 @@
+---
+upgrade:
+  - |
+    Upgrade prometheus alertmanager to newest available version
+
+    * prometheus-alertmanager: 0.28.0 -> 0.28.1
+fixes:
+  - |
+    Resolves an issue with long text being truncated when using
+    Microsoft Teams as an alert destination. See `issue 4222
+    <https://github.com/prometheus/alertmanager/pull/4222>`__
+    for details.
+


### PR DESCRIPTION
* prometheus-alertmanager: 0.28.0 -> 0.28.1

Change-Id: Iec5b936ae77f2d8298803fbfe50f55b2ed69f4b3

Resolves issue with MSTeams where long messages would be truncated. https://github.com/prometheus/alertmanager/pull/4222