### PR TITLE
neutron: Add docker clients for ML2/OVS improvement

### DIFF
--- a/docker/base/Dockerfile.j2
+++ b/docker/base/Dockerfile.j2
@@ -54,6 +54,7 @@ COPY dnf.conf /etc/dnf/dnf.conf
 
 #### BEGIN REPO ENABLEMENT
 {% set base_yum_repo_files = [
+    'docker-ce.repo',
     'grafana.repo',
     'influxdb.repo',
     'mariadb.repo',
@@ -302,6 +303,7 @@ COPY apt_preferences /etc/apt/preferences.d/kolla-custom
 
 {# NOTE(hrw): type field defaults to 'asc' which is used for single keys #}
 {% set base_remote_apt_keys = [
+   {'name': 'docker-ce', 'url': 'https://download.docker.com/linux/debian/gpg'},
    {'name': 'grafana', 'url': 'https://rpm.grafana.com/gpg.key'},
    {'name': 'influxdb', 'url': 'https://repos.influxdata.com/influxdata-archive_compat.key'},
    {'name': 'mariadb', 'url': 'https://downloads.mariadb.com/MariaDB/mariadb-keyring-2019.gpg', 'type': 'gpg'},

--- a/docker/base/docker-ce.repo
+++ b/docker/base/docker-ce.repo
@@ -1,0 +1,6 @@
+[docker-ce]
+name=Docker CE Stable - $basearch
+baseurl=https://download.docker.com/linux/centos/$releasever/$basearch/stable
+enabled=1
+gpgcheck=1
+gpgkey=https://download.docker.com/linux/centos/gpg

--- a/docker/neutron/neutron-base/Dockerfile.j2
+++ b/docker/neutron/neutron-base/Dockerfile.j2
@@ -7,7 +7,7 @@ LABEL maintainer="{{ maintainer }}" name="{{ image_name }}" build-date="{{ build
 
 {% import "macros.j2" as macros with context %}
 
-{{ macros.enable_extra_repos(['openvswitch']) }}
+{{ macros.enable_extra_repos(['docker-ce', 'openvswitch']) }}
 {{ macros.configure_user(name='neutron') }}
 
 {% if base_package_type == 'rpm' %}
@@ -16,6 +16,7 @@ LABEL maintainer="{{ maintainer }}" name="{{ image_name }}" build-date="{{ build
         'conntrack-tools',
         'dnsmasq',
         'dnsmasq-utils',
+        'docker-ce-cli',
         'haproxy',
         'iproute-tc',
         'ipset',
@@ -35,6 +36,7 @@ LABEL maintainer="{{ maintainer }}" name="{{ image_name }}" build-date="{{ build
         'conntrack',
         'dnsmasq',
         'dnsmasq-utils',
+        'docker-ce-cli',
         'haproxy',
         'iproute2',
         'ipset',

--- a/kolla/template/repos.yaml
+++ b/kolla/template/repos.yaml
@@ -2,6 +2,7 @@
 centos:
   ceph: "centos-ceph-reef"
   crb: "crb"
+  docker-ce: "docker-ce"
   epel: "epel"
   erlang: "rabbitmq_rabbitmq-erlang"
   extras: "extras"
@@ -20,6 +21,7 @@ centos:
 centos-aarch64:
   ceph: "centos-ceph-reef"
   crb: "crb"
+  docker-ce: "docker-ce"
   epel: "epel"
   erlang: "copr-rabbitmq-erlang"
   extras: "extras"
@@ -39,6 +41,11 @@ centos-aarch64:
 # https://www.rabbitmq.com/install-debian.html#apt-cloudsmith
 
 debian:
+  docker-ce:
+    url: "https://download.docker.com/linux/debian"
+    suite: "bookworm"
+    component: "stable"
+    gpg_key: "docker-ce.asc"
   erlang:
     url: "https://ppa.launchpadcontent.net/rabbitmq/rabbitmq-erlang/ubuntu"
     suite: "jammy"
@@ -86,6 +93,11 @@ debian:
     gpg_key: "rabbitmq.gpg"
 
 debian-aarch64:
+  docker-ce:
+    url: "https://download.docker.com/linux/debian"
+    suite: "bookworm"
+    component: "stable"
+    gpg_key: "docker-ce.asc"
   erlang:
     url: "https://ppa.launchpadcontent.net/rabbitmq/rabbitmq-erlang/ubuntu"
     suite: "jammy"
@@ -138,6 +150,7 @@ debian-aarch64:
 rocky:
   ceph: "centos-ceph-reef"
   crb: "crb"
+  docker-ce: "docker-ce"
   epel: "epel"
   erlang: "rabbitmq_rabbitmq-erlang"
   extras: "extras"
@@ -156,6 +169,7 @@ rocky:
 rocky-aarch64:
   ceph: "centos-ceph-reef"
   crb: "crb"
+  docker-ce: "docker-ce"
   epel: "epel"
   erlang: "copr-rabbitmq-erlang"
   extras: "extras"
@@ -172,6 +186,11 @@ rocky-aarch64:
   rabbitmq: "rabbitmq_rabbitmq-server"
 
 ubuntu:
+  docker-ce:
+    url: "https://download.docker.com/linux/ubuntu"
+    suite: "noble"
+    component: "stable"
+    gpg_key: "docker-ce.asc"
   erlang:
     url: "https://ppa.launchpadcontent.net/rabbitmq/rabbitmq-erlang/ubuntu"
     suite: "jammy"
@@ -219,6 +238,11 @@ ubuntu:
     gpg_key: "rabbitmq.gpg"
 
 ubuntu-aarch64:
+  docker-ce:
+    url: "https://download.docker.com/linux/ubuntu"
+    suite: "noble"
+    component: "stable"
+    gpg_key: "docker-ce.asc"
   erlang:
     url: "https://ppa.launchpadcontent.net/rabbitmq/rabbitmq-erlang/ubuntu"
     suite: "jammy"


### PR DESCRIPTION
Docker does not support running a container in a given network namespace (netns) so we need a client installed in the Neutron container images.

Related-Bug: #1891469

Change-Id: I5349449183dbb7f4ec2042a21526076fb42591b3