### PR TITLE
neutron: keepalived wrapper script does not rm containers

### DIFF
--- a/docker/neutron/neutron-base/keepalived
+++ b/docker/neutron/neutron-base/keepalived
@@ -30,7 +30,7 @@ LIST=$($CLI ps -a --filter name=${KOLLA_SERVICE}_keepalived_ --format '{{.ID}}:{
 printf "%s\n" "${LIST}" | grep -q "${NAME}$" && NAME="${NAME}_$(date +%Y-%m-%d-%H%M%S-%N)"
 
 echo "Starting a new child container ${NAME} using image ${KOLLA_IMAGE}"
-$CLI run --detach \
+$CLI run --rm --detach \
     -v /etc/kolla/${KOLLA_SERVICE_NAME}:/etc/neutron:ro \
     -v /lib/modules:/lib/modules:ro \
     -v /sbin/modprobe:/sbin/modprobe:ro \


### PR DESCRIPTION
keepalived wrapper script as the only one didn't have --rm in docker/podman invocation - so these didn't get deleted when stopped/crashed/etc.

Closes-Bug: #2127170

Change-Id: I85ae37250ac4ef629b77ade04826a363e8047a91

(cherry picked from commit 90d255daa32be1c80621eb94cba87a2bded570b2)