### PR TITLE
Drop less used Horizon plugins

### DIFF
--- a/docker/horizon/Dockerfile.j2
+++ b/docker/horizon/Dockerfile.j2
@@ -40,7 +40,16 @@ ADD plugins-archive /
 ] %}
 
 {% set horizon_plugins_pip_packages = [
-    '/plugins/*'
+    '/plugins/blazar-dashboard*',
+    '/plugins/designate-dashboard*',
+    '/plugins/heat-dashboard*',
+    '/plugins/horizon-plugin-*',
+    '/plugins/ironic-ui*',
+    '/plugins/magnum-ui*',
+    '/plugins/manila-ui*',
+    '/plugins/masakari-dashboard*',
+    '/plugins/neutron-vpnaas-dashboard*',
+    '/plugins/octavia-dashboard*'
 ] %}
 
 COPY extend_start.sh /usr/local/bin/kolla_extend_start

--- a/releasenotes/notes/drop-horizon-plugins-f6f4d2e50b1adc3b.yaml
+++ b/releasenotes/notes/drop-horizon-plugins-f6f4d2e50b1adc3b.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    Drops Horizon plugins for projects absent in the Release Train. Removes:
+    freezer, mistral, murano, sahara, senlin, solum, tacker, trove, vitrage,
+    watcher, zun dashboards.


### PR DESCRIPTION
This arguably speeds up container image builds and potentially reduces attack surface. Could help with dependecies install issues especially in EOL releases as well.

Allows installations from custom sources via `horizon-plugin-*` path e.g. for Cloudkitty.

freezer, mistral, murano, sahara, senlin, solum, tacker, trove, vitrage, watcher and zun plugins are removed.