### PR TITLE
[2025.2 and older] Create Ironic temp directory

### DIFF
--- a/docker/ironic/ironic-base/extend_start.sh
+++ b/docker/ironic/ironic-base/extend_start.sh
@@ -2,6 +2,7 @@
 
 LOG_PATH=/var/log/kolla/ironic
 METRICS_PATH=/var/lib/ironic-metrics
+TEMP_PATH=/var/lib/ironic/tmp
 
 if [[ ! -d "${LOG_PATH}" ]]; then
     mkdir -p "${LOG_PATH}"
@@ -9,6 +10,10 @@ fi
 if [[ ! -d "${METRICS_PATH}" ]]; then
     sudo mkdir -p "${METRICS_PATH}"
 fi
+if [[ ! -d "${TEMP_PATH}" ]]; then
+    sudo mkdir -p "${TEMP_PATH}"
+fi
+
 if [[ $(stat -c %a "${LOG_PATH}") != "755" ]]; then
     chmod 755 "${LOG_PATH}"
 fi
@@ -17,6 +22,12 @@ if [[ $(stat -c %U:%G "${METRICS_PATH}") != "ironic:ironic" ]]; then
 fi
 if [[ $(stat -c %a "${METRICS_PATH}") != "2775" ]]; then
     sudo chmod 2775 "${METRICS_PATH}"
+fi
+if [[ $(stat -c %U:%G "${TEMP_PATH}") != "ironic:ironic" ]]; then
+    sudo chown ironic:ironic "${TEMP_PATH}"
+fi
+if [[ $(stat -c %a "${TEMP_PATH}") != "700" ]]; then
+    sudo chmod 700 "${TEMP_PATH}"
 fi
 
 . /usr/local/bin/kolla_ironic_extend_start

--- a/releasenotes/notes/fix-bug-2156758-4bbeb2ee873cba47.yaml
+++ b/releasenotes/notes/fix-bug-2156758-4bbeb2ee873cba47.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixes the Ironic temp directory causing invalid cross device links when
+    deploying baremetal images using the virtualmedia boot interface.


### PR DESCRIPTION
Creates a temp directory at /var/lib/ironic/tmp inside the Ironic container.

Change-Id: Ia35c87428841e57a04b42541021d6b7daa3cd43a